### PR TITLE
[Add]SLUserDataSettings, SLUserDataSubsystem. [Fix]SLKeyMappingWidget…

### DIFF
--- a/Config/DefaultUserDataSettings.ini
+++ b/Config/DefaultUserDataSettings.ini
@@ -1,0 +1,24 @@
+
+
+[/Script/StillLoading.SLUserDataSettings]
+PlayerIMC=/Game/StillLoading/Character/IMC/IMC_SLPlayerDefault.IMC_SLPlayerDefault
+DefaultLanguage=EL_Kor
+DefaultBgmVolume=1.000000
+DefaultEffectVolume=1.000000
+DefaultBrightness=1.000000
+DefaultWindowMode=0
+DefaultScreenWidth=1920.000000
+DefaultScreenHeight=1080.000000
+DefaultActionKeyMap=((EIAT_Jump, SpaceBar),(EIAT_Look, Mouse2D),(EIAT_MoveUp, W),(EIAT_MoveDown, S),(EIAT_MoveLeft, A),(EIAT_MoveRight, D),(EIAT_Interaction, F),(EIAT_Attack, LeftMouseButton),(EIAT_PointMove, RightMouseButton),(EIAT_Walk, LeftShift),(EIAT_Menu, Escape))
+DefaultMoveUpKey=W
+DefaultMoveDownKey=S
+DefaultMoveLeftKey=A
+DefaultMoveRightKey=D
+DefaultWalkKey=LeftShift
+DefaultJumpKey=SpaceBar
+DefaultAttackKey=LeftMouseButton
+DefaultInteractionKey=F
+DefaultLookKey=Mouse2D
+DefaultPointMoveKey=RightMouseButton
+DefaultMenuKey=Escape
+

--- a/Content/StillLoading/UI/Widget/AdditiveWidget/SubWidget/WBP_SLKeySettingWidget.uasset
+++ b/Content/StillLoading/UI/Widget/AdditiveWidget/SubWidget/WBP_SLKeySettingWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d298b9d18ba0ee65907936dc9f79bdda768aa98d2ffb01fecb535ea7b116cbe
-size 48807
+oid sha256:793061304b400dda301d765e80011e990c59200eb52fe716582aaf50a5accb9a
+size 48442

--- a/Source/StillLoading/SubSystem/SLUserDataSettings.cpp
+++ b/Source/StillLoading/SubSystem/SLUserDataSettings.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SubSystem/SLUserDataSettings.h"
+

--- a/Source/StillLoading/SubSystem/SLUserDataSettings.h
+++ b/Source/StillLoading/SubSystem/SLUserDataSettings.h
@@ -1,0 +1,45 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "UI/SLUITypes.h"
+#include "Character//DynamicIMCComponent/SLDynamicIMCComponent.h"
+#include "SLUserDataSettings.generated.h"
+
+class UInputMappingContext;
+
+UCLASS(Config = UserDataSettings, DefaultConfig, meta = (DisplayName = "UserDataSubsystemSettings"))
+class STILLLOADING_API USLUserDataSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+	
+public:
+	UPROPERTY(EditAnywhere, Config, Category = "DefaultIMC")
+	TSoftObjectPtr<UInputMappingContext> PlayerIMC = nullptr;
+
+	UPROPERTY(EditAnywhere, Config, Category = "DefaultLanguageSettings")
+	ESLLanguageType DefaultLanguage = ESLLanguageType::EL_Kor;
+
+	UPROPERTY(EditAnywhere, Config, Category = "DefaultAudioSettings")
+	float DefaultBgmVolume = 1.0f;
+
+	UPROPERTY(EditAnywhere, Config, Category = "DefaultAudioSettings")
+	float DefaultEffectVolume = 1.0f;
+
+	UPROPERTY(EditAnywhere, Config, Category = "DefaultScreenSettings")
+	float DefaultBrightness = 1.0f;
+
+	UPROPERTY(EditAnywhere, Config, Category = "DefaultScreenSettings")
+	int32 DefaultWindowMode = 0;
+
+	UPROPERTY(EditAnywhere, Config, Category = "DefaultScreenSettings")
+	float DefaultScreenWidth = 1920.0f;
+
+	UPROPERTY(EditAnywhere, Config, Category = "DefaultScreenSettings")
+	float DefaultScreenHeight = 1080.0f;
+	
+	UPROPERTY(EditAnywhere, Config, Category = "DefaultKeySettings")
+	TMap<EInputActionType, FKey> DefaultActionKeyMap;
+};

--- a/Source/StillLoading/SubSystem/SLUserDataSubsystem.cpp
+++ b/Source/StillLoading/SubSystem/SLUserDataSubsystem.cpp
@@ -1,0 +1,304 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SubSystem/SLUserDataSubsystem.h"
+#include "GameFramework/GameUserSettings.h"
+#include "Engine/RendererSettings.h"
+#include "UI/SLUISubsystem.h"
+#include "SubSystem/SLUserDataSettings.h"
+#include "InputMappingContext.h"
+
+void USLUserDataSubsystem::ApplyLoadedUserData()
+{
+	// TODO : Load User Data From SaveSubsystem
+
+	ApplyLanguageMode();
+	ApplyBgmVolume();
+	ApplyEffectVolume();
+	ApplyWindowMode();
+	ApplyResolution();
+	ApplyBrightness();
+}
+
+void USLUserDataSubsystem::ApplyDefaultUserData()
+{
+	CheckValidOfUserDataSettings();
+
+	SetLanguage(UserDataSettings->DefaultLanguage);
+	SetBgmVolume(UserDataSettings->DefaultBgmVolume);
+	SetEffectVolume(UserDataSettings->DefaultEffectVolume);
+	SetBrightness(UserDataSettings->DefaultBrightness);
+	SetWindowMode(UserDataSettings->DefaultWindowMode);
+	SetScreenSize({ UserDataSettings->DefaultScreenWidth, UserDataSettings->DefaultScreenHeight });
+
+	if (ActionKeyMap.IsEmpty())
+	{
+		LoadKeyMapFromIMC();
+	}
+
+	for (const TPair<EInputActionType, FKey> ActionTypeKeyPair : UserDataSettings->DefaultActionKeyMap)
+	{
+		UpdateMappingKey(ActionTypeKeyPair.Key, ActionTypeKeyPair.Value);
+	}
+}
+
+void USLUserDataSubsystem::SetLanguage(ESLLanguageType NewType)
+{
+	LanguageType = NewType;
+	ApplyLanguageMode();
+}
+
+void USLUserDataSubsystem::SetBgmVolume(float VolumeValue)
+{
+	BgmVolume = FMath::Clamp(VolumeValue, 0.0f, 1.0f);
+	ApplyBgmVolume();
+}
+
+void USLUserDataSubsystem::SetEffectVolume(float VolumeValue)
+{
+	EffectVolume = FMath::Clamp(VolumeValue, 0.0f, 1.0f);
+	ApplyEffectVolume();
+}
+
+void USLUserDataSubsystem::SetBrightness(float BrightnessValue)
+{
+	Brightness = FMath::Clamp(BrightnessValue, 0.0f, 1.0f);
+	ApplyBrightness();
+}
+
+void USLUserDataSubsystem::SetWindowMode(int32 ModeValue)
+{
+	WindowMode = ModeValue % 3;
+	ApplyWindowMode();
+}
+
+void USLUserDataSubsystem::SetScreenSize(const TPair<float, float>& SizeValue)
+{
+	ScreenWidth = SizeValue.Key;
+	ScreenHeight = SizeValue.Value;
+	ApplyResolution();
+}
+
+ESLLanguageType USLUserDataSubsystem::GetCurrentLanguage() const
+{
+	return LanguageType;
+}
+
+float USLUserDataSubsystem::GetCurrentBgmVolume() const
+{
+	return BgmVolume;
+}
+
+float USLUserDataSubsystem::GetCurrentEffectVolume() const
+{
+	return EffectVolume;
+}
+
+float USLUserDataSubsystem::GetCurrentBrightness() const
+{
+	return Brightness;
+}
+
+int32 USLUserDataSubsystem::GetCurrentWindowMode() const
+{
+	return WindowMode;
+}
+
+TPair<float, float> USLUserDataSubsystem::GetCurrentScreenSize()
+{
+	return { ScreenWidth, ScreenHeight };
+}
+
+bool USLUserDataSubsystem::UpdateMappingKey(EInputActionType TargetType, const FKey& KeyValue)
+{
+	if (KeySet.Contains(KeyValue))
+	{
+		return false;
+	}
+
+	if (ActionKeyMap.Contains(TargetType))
+	{
+		const UInputAction* TargetAction = ActionKeyMap[TargetType].Action;
+		FKey OriginKey = ActionKeyMap[TargetType].Key;
+
+		ActionKeyMap[TargetType].Key = KeyValue;
+
+		KeySet.Remove(OriginKey);
+		KeySet.Add(KeyValue);
+
+		PlayerIMC->UnmapKey(TargetAction, OriginKey);
+		PlayerIMC->MapKey(TargetAction, KeyValue);
+	}
+
+	return true;
+}
+
+const TMap<EInputActionType, FEnhancedActionKeyMapping>& USLUserDataSubsystem::GetActionKeyMap()
+{
+	if (ActionKeyMap.IsEmpty())
+	{
+		LoadKeyMapFromIMC();
+	}
+
+	return ActionKeyMap;
+}
+
+void USLUserDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+
+	CheckValidOfUserDataSettings();
+	PlayerIMC = UserDataSettings->PlayerIMC.LoadSynchronous();
+}
+
+void USLUserDataSubsystem::ApplyLanguageMode()
+{
+	CheckValidOfUISubsystem();
+	UISubsystem->SetLanguageToUI(LanguageType);
+}
+
+void USLUserDataSubsystem::ApplyBgmVolume()
+{
+	// TODO : Apply Bgm Volume To Bgm Audio Component
+}
+
+void USLUserDataSubsystem::ApplyEffectVolume()
+{
+	CheckValidOfUISubsystem();
+	UISubsystem->SetEffectVolume(EffectVolume);
+}
+
+void USLUserDataSubsystem::ApplyResolution()
+{
+	CheckValidOfGameUserSettings();
+	GameUserSettings->SetScreenResolution(FIntPoint(ScreenWidth, ScreenHeight));
+	GameUserSettings->ApplySettings(false);
+}
+
+void USLUserDataSubsystem::ApplyBrightness()
+{
+	CheckValidOfRendererSettings();
+	RendererSettings->DefaultFeatureAutoExposureBias = Brightness;
+
+	FPropertyChangedEvent PropertyChangedEvent(URendererSettings::StaticClass()->
+		FindPropertyByName(GET_MEMBER_NAME_CHECKED(URendererSettings, DefaultFeatureAutoExposureBias)));
+
+	RendererSettings->PostEditChangeProperty(PropertyChangedEvent);
+	RendererSettings->SaveConfig();
+}
+
+void USLUserDataSubsystem::ApplyWindowMode()
+{
+	CheckValidOfGameUserSettings();
+	GameUserSettings->SetFullscreenMode((EWindowMode::Type)WindowMode);
+	GameUserSettings->ApplySettings(false);
+}
+
+void USLUserDataSubsystem::LoadKeyMapFromIMC()
+{
+	checkf(IsValid(PlayerIMC), TEXT("IMC is invalid"));
+
+	TArray<FEnhancedActionKeyMapping> ActionKeyMappings = PlayerIMC->GetMappings();
+
+	for (const FEnhancedActionKeyMapping& ActionKeyMapping : ActionKeyMappings)
+	{
+		AddMappingDataToKeyMap(ActionKeyMapping);
+	}
+}
+
+void USLUserDataSubsystem::AddMappingDataToKeyMap(const FEnhancedActionKeyMapping& ActionKeyMapping)
+{
+	EInputActionType ActionType = EInputActionType::EIAT_None;
+
+	if (ActionKeyMapping.Action->GetName().Contains(TEXT("MoveUp")))
+	{
+		ActionType = EInputActionType::EIAT_MoveUp;
+	}
+	else if (ActionKeyMapping.Action->GetName().Contains(TEXT("MoveDown")))
+	{
+		ActionType = EInputActionType::EIAT_MoveDown;
+	}
+	else if (ActionKeyMapping.Action->GetName().Contains(TEXT("MoveLeft")))
+	{
+		ActionType = EInputActionType::EIAT_MoveLeft;
+	}
+	else if (ActionKeyMapping.Action->GetName().Contains(TEXT("MoveRight")))
+	{
+		ActionType = EInputActionType::EIAT_MoveRight;
+	}
+	else if (ActionKeyMapping.Action->GetName().Contains(TEXT("Walk")))
+	{
+		ActionType = EInputActionType::EIAT_Walk;
+	}
+	else if (ActionKeyMapping.Action->GetName().Contains(TEXT("Jump")))
+	{
+		ActionType = EInputActionType::EIAT_Jump;
+	}
+	else if (ActionKeyMapping.Action->GetName().Contains(TEXT("Attack")))
+	{
+		ActionType = EInputActionType::EIAT_Attack;
+	}
+	else if (ActionKeyMapping.Action->GetName().Contains(TEXT("Interation")))
+	{
+		ActionType = EInputActionType::EIAT_Interaction;
+	}
+	else if (ActionKeyMapping.Action->GetName().Contains(TEXT("PointMove")))
+	{
+		ActionType = EInputActionType::EIAT_PointMove;
+	}
+	else if (ActionKeyMapping.Action->GetName().Contains(TEXT("Menu")))
+	{
+		ActionType = EInputActionType::EIAT_Menu;
+	}
+	else if (ActionKeyMapping.Action->GetName().Contains(TEXT("Look")))
+	{
+		ActionType = EInputActionType::EIAT_Look;
+	}
+
+	KeySet.Add(ActionKeyMapping.Key);
+	ActionKeyMap.Add(ActionType, ActionKeyMapping);
+}
+
+void USLUserDataSubsystem::CheckValidOfGameUserSettings()
+{
+	if (IsValid(GameUserSettings))
+	{
+		return;
+	}
+
+	GameUserSettings = GEngine->GetGameUserSettings();
+	checkf(IsValid(GameUserSettings), TEXT("Game User Settings is invalid"));
+}
+
+void USLUserDataSubsystem::CheckValidOfRendererSettings()
+{
+	if (IsValid(RendererSettings))
+	{
+		return;
+	}
+
+	RendererSettings = GetMutableDefault<URendererSettings>();
+	checkf(IsValid(RendererSettings), TEXT("Renderer Settings is invalid"));
+}
+
+void USLUserDataSubsystem::CheckValidOfUISubsystem()
+{
+	if (IsValid(UISubsystem))
+	{
+		return;
+	}
+
+	UISubsystem = GetGameInstance()->GetSubsystem<USLUISubsystem>();
+	checkf(IsValid(UISubsystem), TEXT("UI Subsystem is invalid"));
+}
+
+void USLUserDataSubsystem::CheckValidOfUserDataSettings()
+{
+	if (IsValid(UserDataSettings))
+	{
+		return;
+	}
+
+	UserDataSettings = GetDefault<USLUserDataSettings>();
+	checkf(IsValid(UserDataSettings), TEXT("User Data Settings is invalid"));
+}

--- a/Source/StillLoading/SubSystem/SLUserDataSubsystem.h
+++ b/Source/StillLoading/SubSystem/SLUserDataSubsystem.h
@@ -1,0 +1,103 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "UI/SLUITypes.h"
+#include "Character//DynamicIMCComponent/SLDynamicIMCComponent.h"
+#include "SLUserDataSubsystem.generated.h"
+
+class USLUserDataSettings;
+class UInputMappingContext;
+class UGameUserSettings;
+class URendererSettings;
+class USLUISubsystem;
+
+UCLASS()
+class STILLLOADING_API USLUserDataSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+	
+public:
+	void ApplyLoadedUserData();
+	void ApplyDefaultUserData();
+
+	void SetLanguage(ESLLanguageType NewType);
+	void SetBgmVolume(float VolumeValue);
+	void SetEffectVolume(float VolumeValue);
+	void SetBrightness(float BrightnessValue);
+	void SetWindowMode(int32 ModeValue);
+	void SetScreenSize(const TPair<float, float>& SizeValue);
+	
+	ESLLanguageType GetCurrentLanguage() const;
+	float GetCurrentBgmVolume() const;
+	float GetCurrentEffectVolume() const;
+	float GetCurrentBrightness() const;
+	int32 GetCurrentWindowMode() const;
+	TPair<float, float> GetCurrentScreenSize();
+
+	bool UpdateMappingKey(EInputActionType TargetType, const FKey& KeyValue);
+	const TMap<EInputActionType, FEnhancedActionKeyMapping>& GetActionKeyMap();
+
+private:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+
+	void ApplyLanguageMode();
+	void ApplyBgmVolume();
+	void ApplyEffectVolume();
+	void ApplyResolution();
+	void ApplyBrightness();
+	void ApplyWindowMode();
+
+	void LoadKeyMapFromIMC();
+	void AddMappingDataToKeyMap(const FEnhancedActionKeyMapping& ActionKeyMapping);
+
+	void CheckValidOfGameUserSettings();
+	void CheckValidOfRendererSettings();
+	void CheckValidOfUISubsystem();
+	void CheckValidOfUserDataSettings();
+
+private:
+	UPROPERTY()
+	const USLUserDataSettings* UserDataSettings = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<UGameUserSettings> GameUserSettings = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<URendererSettings> RendererSettings = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<USLUISubsystem> UISubsystem = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<UInputMappingContext> PlayerIMC = nullptr;
+
+	UPROPERTY()
+	TSet<FKey> KeySet;
+
+	UPROPERTY()
+	TMap<EInputActionType, FEnhancedActionKeyMapping> ActionKeyMap;
+
+	UPROPERTY()
+	ESLLanguageType LanguageType = ESLLanguageType::EL_Kor;
+
+	UPROPERTY()
+	float BgmVolume = 1.0f;
+
+	UPROPERTY()
+	float EffectVolume = 1.0f;
+
+	UPROPERTY()
+	float Brightness = 1.0f;
+
+	UPROPERTY()
+	int32 WindowMode = 0;
+
+	UPROPERTY()
+	float ScreenWidth = 1920.0f;
+
+	UPROPERTY()
+	float ScreenHeight = 1080.0f;
+};

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SLAdditiveWidget.cpp
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SLAdditiveWidget.cpp
@@ -8,10 +8,7 @@
 
 void USLAdditiveWidget::FindWidgetData()
 {
-	if (!CheckValidOfUISubsystem())
-	{
-		return;
-	}
+	CheckValidOfUISubsystem();
 
 	const UDataTable* ImageDataTable = UISubsystem->GetImageDataTable();
 	const FString ContextString(TEXT("Image Data Table"));
@@ -39,8 +36,6 @@ void USLAdditiveWidget::FindWidgetData()
 
 void USLAdditiveWidget::CloseWidget()
 {
-	if (CheckValidOfUISubsystem())
-	{
-		UISubsystem->RemoveCurrentAdditiveWidget();
-	}
+	CheckValidOfUISubsystem();
+	UISubsystem->RemoveCurrentAdditiveWidget();
 }

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SLOptionWidget.h
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SLOptionWidget.h
@@ -12,6 +12,7 @@ class USlider;
 class UExpandableArea;
 class UGameUserSettings;
 class URendererSettings;
+class USLUserDataSubsystem;
 
 UCLASS()
 class STILLLOADING_API USLOptionWidget : public USLAdditiveWidget
@@ -76,8 +77,7 @@ private:
 	UFUNCTION()
 	void OnClickedQuit();
 
-	bool CheckValidOfGameUserSettings();
-	bool CheckValidOfRendererSettings();
+	void CheckValidOfUserDataSubsystem();
 
 	void UpdateScreenModeButton();
 	void UpdateLanguageButton();
@@ -174,13 +174,7 @@ private:
 	//
 
 	UPROPERTY()
-	TObjectPtr<UGameUserSettings> GameUserSettings = nullptr;
-
-	UPROPERTY()
-	TObjectPtr<URendererSettings> RendererSettings = nullptr;
-
-	bool bIsFullScreen = true;
-	bool bIsKor = true;
+	TObjectPtr<USLUserDataSubsystem> UserDataSubsystem = nullptr;
 
 	static const TArray<TPair<float, float>> ResolutionSet;
 };

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeyMappingWidget.cpp
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeyMappingWidget.cpp
@@ -7,12 +7,11 @@
 #include "Components/TextBlock.h"
 
 
-void USLKeyMappingWidget::InitWidget(const FName& NewTagText, const FKey& NewKey)
+void USLKeyMappingWidget::InitWidget(const FName& NewTagText, EInputActionType NewActionType)
 {
-	UpdateTagText(NewTagText);
-	UpdateKeyText(NewKey);
-
+	ActionType = NewActionType;
 	ChangeButton->OnClicked.AddDynamic(this, &ThisClass::OnClickedChangeKey);
+	UpdateTagText(NewTagText);
 }
 
 void USLKeyMappingWidget::UpdateTagText(const FName& NewTagText)
@@ -20,10 +19,9 @@ void USLKeyMappingWidget::UpdateTagText(const FName& NewTagText)
 	TagText->SetText(FText::FromName(NewTagText));
 }
 
-void USLKeyMappingWidget::UpdateKeyText(const FKey& NewKey)
+void USLKeyMappingWidget::UpdateKeyText(const FName& KeyText)
 {
-	InputKey = NewKey;
-	KeyTextBox->SetText(FText::FromString(InputKey.ToString()));
+	KeyTextBox->SetText(FText::FromName(KeyText));
 }
 
 void USLKeyMappingWidget::SetVisibilityButton(bool bIsVisible)
@@ -45,5 +43,5 @@ void USLKeyMappingWidget::SetIsEnabledButton(bool bIsEnable)
 
 void USLKeyMappingWidget::OnClickedChangeKey()
 {
-	KeyDelegate.Broadcast(InputKey);
+	KeyDelegate.Broadcast(ActionType);
 }

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeyMappingWidget.h
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeyMappingWidget.h
@@ -4,12 +4,13 @@
 
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
+#include "Character//DynamicIMCComponent/SLDynamicIMCComponent.h"
 #include "SLKeyMappingWidget.generated.h"
 
 class UButton;
 class UTextBlock;
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnClickedKey, const FKey&, KeyName);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnClickedKey, EInputActionType, KeyName);
 
 UCLASS()
 class STILLLOADING_API USLKeyMappingWidget : public UUserWidget
@@ -17,9 +18,9 @@ class STILLLOADING_API USLKeyMappingWidget : public UUserWidget
 	GENERATED_BODY()
 	
 public:
-	void InitWidget(const FName& NewTagText, const FKey& NewKey);
+	void InitWidget(const FName& NewTagText, EInputActionType NewActionType);
 	void UpdateTagText(const FName& NewTagText);
-	void UpdateKeyText(const FKey& NewKey);
+	void UpdateKeyText(const FName& KeyText);
 
 	void SetVisibilityButton(bool bIsVisible);
 	void SetIsEnabledButton(bool bIsEnable);
@@ -42,5 +43,6 @@ private:
 	UPROPERTY(Meta = (BindWidget))
 	TObjectPtr<UTextBlock> TagText = nullptr;
 
+	EInputActionType ActionType = EInputActionType::EIAT_None;
 	FKey InputKey;
 };

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeySettingWidget.h
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeySettingWidget.h
@@ -4,32 +4,15 @@
 
 #include "CoreMinimal.h"
 #include "UI/Widget/AdditiveWidget/SLAdditiveWidget.h"
-#include "Character/DynamicIMCComponent/SLDynamicIMCComponent.h"
+#include "Character//DynamicIMCComponent/SLDynamicIMCComponent.h"
+//#include "EnhancedActionKeyMapping.h"
 #include "SLKeySettingWidget.generated.h"
 
+class USLUserDataSubsystem;
 class USLKeyMappingWidget;
 class UTextBlock;
 class UButton;
 class UImage;
-
-USTRUCT(BlueprintType)
-struct FSLKeySettingData
-{
-	GENERATED_BODY()
-
-public:
-	UPROPERTY()
-	FName ActionName = "";
-
-	//UPROPERTY()
-	//EInputActionType ActionType = EInputActionType::None;
-
-	UPROPERTY()
-	FEnhancedActionKeyMapping MappingData;
-
-	UPROPERTY()
-	TObjectPtr<USLKeyMappingWidget> ElementWidget = nullptr;
-};
 
 UCLASS()
 class STILLLOADING_API USLKeySettingWidget : public USLAdditiveWidget
@@ -49,22 +32,20 @@ protected:
 
 private:
 	UFUNCTION()
-	void OnClickedKeyDataButton(const FKey& TargetKey);
+	void OnClickedKeyDataButton(EInputActionType TargetAction);
 
-	void InitKeyDataMap();
-	void AddToKeyDataMap(const FEnhancedActionKeyMapping& TargetData);
+	void InitElementWidget();
 	void UpdateKeyMapping(const FKey& InputKey);
+	void SetFocusToTargetButton(EInputActionType TargetAction, bool bIsFocus);
 
-	void SetFocusToTargetButton(const FKey& TargetKey, bool bIsFocus);
-
-public:
-	UPROPERTY(EditAnywhere)
-	TObjectPtr<UInputMappingContext> IMC = nullptr;
+	void CheckValidOfUserDateSubsystem();
 
 private:
 	UPROPERTY()
-	TMap<FKey, FSLKeySettingData> KeyDataMap;
+	TObjectPtr<USLUserDataSubsystem> UserDataSubsystem = nullptr;
 
+	UPROPERTY()
+	TMap<EInputActionType, USLKeyMappingWidget*> ActionWidgetMap;
 
 	UPROPERTY(Meta = (BindWidget))
 	TObjectPtr<UButton> CloseButton = nullptr;
@@ -109,7 +90,18 @@ private:
 	UPROPERTY(Meta = (BindWidget))
 	TObjectPtr<USLKeyMappingWidget> Menu = nullptr;
 
-	FKey TempKey;
+	static const FName MoveUpTagIndex;
+	static const FName MoveDownTagIndex;
+	static const FName MoveLeftTagIndex;
+	static const FName MoveRightTagIndex;
+	static const FName WalkTagIndex;
+	static const FName JumpTagIndex;
+	static const FName AttackTagIndex;
+	static const FName InteractionTagIndex;
+	static const FName PointMoveTagIndex;
+	static const FName LookTagIndex;
+	static const FName MenuTagIndex;
 
+	EInputActionType TargetActionType = EInputActionType::EIAT_None;
 	bool bOnClickedChange = false;
 };

--- a/Source/StillLoading/UI/Widget/SLBaseWidget.cpp
+++ b/Source/StillLoading/UI/Widget/SLBaseWidget.cpp
@@ -50,32 +50,18 @@ void USLBaseWidget::OnEndedCloseAnim()
 
 void USLBaseWidget::PlayUISound(ESLUISoundType SoundType)
 {
-	if (!CheckValidOfUISubsystem())
+	CheckValidOfUISubsystem();
+	UISubsystem->PlayUISound(SoundType);
+}
+
+void USLBaseWidget::CheckValidOfUISubsystem()
+{
+	if (IsValid(UISubsystem))
 	{
 		return;
 	}
 
-	UISubsystem->PlayUISound(SoundType);
-}
-
-bool USLBaseWidget::CheckValidOfUISubsystem()
-{
-	if (IsValid(UISubsystem))
-	{
-		return true;
-	}
-
-	if (!IsValid(GetGameInstance()))
-	{
-		return false;
-	}
-
+	checkf(IsValid(GetGameInstance()), TEXT("GameInstance is invalid"));
 	UISubsystem = GetGameInstance()->GetSubsystem<USLUISubsystem>();
-
-	if (!IsValid(UISubsystem))
-	{
-		return false;
-	}
-
-	return true;
+	checkf(IsValid(UISubsystem), TEXT("UISubsystem is invalid"));
 }

--- a/Source/StillLoading/UI/Widget/SLBaseWidget.h
+++ b/Source/StillLoading/UI/Widget/SLBaseWidget.h
@@ -35,7 +35,7 @@ protected:
 
 	void PlayUISound(ESLUISoundType SoundType);
 
-	bool CheckValidOfUISubsystem();
+	void CheckValidOfUISubsystem();
 
 protected:
 	UPROPERTY()


### PR DESCRIPTION
…, SLKeySettingWidget, SLAdditiveWidget, SLOptionWidget, SLBaseWidget

유저가 설정한 환경 변수 관리할 SLUserDataSubsystem 생성 및 구현
SLUserDataSubsystem에서 필요한 데이터를 로드할 SLUserDataSettings 생성 및 구현
- 키 셋팅에 따라 IMC의 키 매핑을 변경하기 위해 IMC 에셋 로드
- 추후 기본값으로 돌리는 기능의 버튼을 만들기 위해 Default 값 저장할 변수들 선언

기존에 Option Widget과 KeySettingWidget에서 각자 변경 값을 가지고 있던 구조
-> 직접 값을 소지하지 않고, SLUserDataSubsystem으로부터 받아오거나 변경 시 호출하는 구조

기존 키 셋팅 상황에서 다른 곳을 클릭하거나 중복된 키 입력한 경우 이전 상태로 돌아오지 않는 현상 수정.

요청 사항 : DynamicIMCComponent가 가지고 있는 EInputActiionType 열거형이 별개의 헤더에 존재하면 좋겠음.
SLUserDataSubsystem, SLUserDataSettings, SLKeySettingWidget, SLKeyMappingWidget에서 해당 열거형을 참조하는데
열거형만 참조하는 것이 아니라 DynamicIMCComponent 헤더 전체를 읽어야하므로 비효율적