### PR TITLE
[Add] SLSoundSubsystem. SLSoundSettings, SLSoundTypes, SoundDataAsset…

### DIFF
--- a/Config/DefaultSoundSetting.ini
+++ b/Config/DefaultSoundSetting.ini
@@ -1,0 +1,3 @@
+[/Script/StillLoading.SLSoundSettings]
+ChapterSoundMap=((EC_Intro, "/Game/StillLoading/Sound/DataAssets/DA_Chapter0SoundData.DA_Chapter0SoundData"),(EC_Chapter2D, "/Game/StillLoading/Sound/DataAssets/DA_Chapter1SoundData.DA_Chapter1SoundData"),(EC_Chapter2_5D, "/Game/StillLoading/Sound/DataAssets/DA_Chapter2SoundData.DA_Chapter2SoundData"),(EC_Chapter3D, "/Game/StillLoading/Sound/DataAssets/DA_Chapter3SoundData.DA_Chapter3SoundData"),(EC_ChapterHighQuality, "/Game/StillLoading/Sound/DataAssets/DA_Chapter4SoundData.DA_Chapter4SoundData"))
+

--- a/Content/StillLoading/Sound/DataAssets/DA_Chapter0SoundData.uasset
+++ b/Content/StillLoading/Sound/DataAssets/DA_Chapter0SoundData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b95364e4d9ef13fb3f6563299847ecc21a3bb9e215d34cd354e44537ca0d0135
+size 3523

--- a/Content/StillLoading/Sound/DataAssets/DA_Chapter1SoundData.uasset
+++ b/Content/StillLoading/Sound/DataAssets/DA_Chapter1SoundData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2f340da431aa82577037d25b48587500c4902daf6f33bfc4d2099a192450c77
+size 2616

--- a/Content/StillLoading/Sound/DataAssets/DA_Chapter2SoundData.uasset
+++ b/Content/StillLoading/Sound/DataAssets/DA_Chapter2SoundData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9aee581d3bd333a55ecfe85d2fbe76e9186068aaf7308563c98c49d6302de663
+size 2616

--- a/Content/StillLoading/Sound/DataAssets/DA_Chapter3SoundData.uasset
+++ b/Content/StillLoading/Sound/DataAssets/DA_Chapter3SoundData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30e540bcbc27bb424b790bf00439b25c4d1f145bc2ba0f204f829379716a364b
+size 2616

--- a/Content/StillLoading/Sound/DataAssets/DA_Chapter4SoundData.uasset
+++ b/Content/StillLoading/Sound/DataAssets/DA_Chapter4SoundData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7abb58a07dd115d4dc0dbaceb1c157fac8fd0fcae07017ffd40cf20f72674f3
+size 2616

--- a/Source/StillLoading/SubSystem/DataAssets/SLSoundDataAsset.cpp
+++ b/Source/StillLoading/SubSystem/DataAssets/SLSoundDataAsset.cpp
@@ -1,0 +1,26 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SubSystem/DataAssets/SLSoundDataAsset.h"
+
+USoundBase* USLSoundDataAsset::GetUISoundSource(ESLUISoundType SoundType)
+{
+	if (UISoundMap.Contains(SoundType) &&
+		IsValid(UISoundMap[SoundType]))
+	{
+		return UISoundMap[SoundType];
+	}
+
+	return nullptr;
+}
+
+USoundBase* USLSoundDataAsset::GetBgmSoundSource(ESLBgmSoundType SoundType)
+{
+	if (BgmSoundMap.Contains(SoundType) &&
+		IsValid(BgmSoundMap[SoundType]))
+	{
+		return BgmSoundMap[SoundType];
+	}
+
+	return nullptr;
+}

--- a/Source/StillLoading/SubSystem/DataAssets/SLSoundDataAsset.h
+++ b/Source/StillLoading/SubSystem/DataAssets/SLSoundDataAsset.h
@@ -1,0 +1,26 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataAsset.h"
+#include "SubSystem/SLSoundTypes.h"
+#include "UI/SLUITypes.h"
+#include "SLSoundDataAsset.generated.h"
+
+UCLASS()
+class STILLLOADING_API USLSoundDataAsset : public UDataAsset
+{
+	GENERATED_BODY()
+	
+public:
+	USoundBase* GetUISoundSource(ESLUISoundType SoundType);
+	USoundBase* GetBgmSoundSource(ESLBgmSoundType SoundType);
+
+private:
+	UPROPERTY(EditAnywhere)
+	TMap<ESLUISoundType, USoundBase*> UISoundMap;
+
+	UPROPERTY(EditAnywhere)
+	TMap<ESLBgmSoundType, USoundBase*> BgmSoundMap;
+};

--- a/Source/StillLoading/SubSystem/SLSoundSettings.cpp
+++ b/Source/StillLoading/SubSystem/SLSoundSettings.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SubSystem/SLSoundSettings.h"
+

--- a/Source/StillLoading/SubSystem/SLSoundSettings.h
+++ b/Source/StillLoading/SubSystem/SLSoundSettings.h
@@ -1,0 +1,35 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "UI/SLUITypes.h"
+#include "SLSoundSettings.generated.h"
+
+class USLSoundDataAsset;
+
+UCLASS(Config = SoundSetting, DefaultConfig, meta = (DisplayName = "Sound Subsystem Settings"))
+class STILLLOADING_API USLSoundSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+	
+public:
+	UPROPERTY(EditAnywhere, Config, Category = "SoundSourceData")
+	TMap < ESLChapterType, TSoftObjectPtr<USLSoundDataAsset>> ChapterSoundMap;
+
+	/*UPROPERTY(EditAnywhere, Config, Category = "SoundSourceData")
+	TSoftObjectPtr<USLSoundDataAsset> Chapter0SoundData = nullptr;
+
+	UPROPERTY(EditAnywhere, Config, Category = "SoundSourceData")
+	TSoftObjectPtr<USLSoundDataAsset> Chapter1SoundData = nullptr;
+
+	UPROPERTY(EditAnywhere, Config, Category = "SoundSourceData")
+	TSoftObjectPtr<USLSoundDataAsset> Chapter2SoundData = nullptr;
+
+	UPROPERTY(EditAnywhere, Config, Category = "SoundSourceData")
+	TSoftObjectPtr<USLSoundDataAsset> Chapter3SoundData = nullptr;
+
+	UPROPERTY(EditAnywhere, Config, Category = "SoundSourceData")
+	TSoftObjectPtr<USLSoundDataAsset> Chapter4SoundData = nullptr;*/
+};

--- a/Source/StillLoading/SubSystem/SLSoundSubsystem.cpp
+++ b/Source/StillLoading/SubSystem/SLSoundSubsystem.cpp
@@ -1,0 +1,162 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SubSystem/SLSoundSubsystem.h"
+#include "SubSystem/SLSoundSettings.h"
+#include "UI/SLUISubsystem.h"
+#include "Components/AudioComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "SubSystem/DataAssets/SLSoundDataAsset.h"
+
+void USLSoundSubsystem::PlayUISound(ESLUISoundType SoundType)
+{
+	CheckValidOfSoundDataAsset();
+
+	USoundBase* SoundSource = SoundDataAsset->GetUISoundSource(SoundType);
+
+	if (!IsValid(SoundSource))
+	{
+		return;
+	}
+
+	StopUISound();
+
+	if (!IsValid(UIAudioComp))
+	{
+		UIAudioComp = UGameplayStatics::CreateSound2D(GetGameInstance(), SoundSource, EffectVolume);
+		UIAudioComp->bAutoDestroy = false;
+	}
+	
+	UIAudioComp->SetSound(SoundSource);
+	UIAudioComp->Play();
+}
+
+void USLSoundSubsystem::StopUISound()
+{
+	if (IsValid(UIAudioComp) && UIAudioComp->IsPlaying())
+	{
+		UIAudioComp->Stop();
+	}
+}
+
+void USLSoundSubsystem::PlayBgmSound(ESLBgmSoundType SoundType)
+{
+	CheckValidOfSoundDataAsset();
+
+	USoundBase* SoundSource = SoundDataAsset->GetBgmSoundSource(SoundType);
+
+	if (!IsValid(SoundSource))
+	{
+		return;
+	}
+
+	StopBgmSound();
+
+	if (!IsValid(BgmAudioComp))
+	{
+		BgmAudioComp = UGameplayStatics::CreateSound2D(GetGameInstance(), SoundSource, BgmVolume);
+		BgmAudioComp->bAutoDestroy = false;
+	}
+
+	BgmAudioComp->SetSound(SoundSource);
+	BgmAudioComp->Play();
+}
+
+void USLSoundSubsystem::StopBgmSound()
+{
+	if (IsValid(BgmAudioComp))
+	{
+		BgmAudioComp->Stop();
+	}
+}
+
+void USLSoundSubsystem::SetBgmVolume(float VolumeValue)
+{
+	BgmVolume = FMath::Clamp(VolumeValue, 0.0f, 1.0f);
+
+	if (IsValid(BgmAudioComp))
+	{
+		BgmAudioComp->SetVolumeMultiplier(BgmVolume);
+
+		if (FMath::IsNearlyZero(BgmVolume))
+		{
+			BgmAudioComp->SetPaused(true);
+			return;
+		}
+
+		if (BgmAudioComp->bIsPaused)
+		{
+			BgmAudioComp->SetPaused(false);
+		}
+	}
+}
+
+void USLSoundSubsystem::SetEffectVolume(float VolumeValue)
+{
+	EffectVolume = FMath::Clamp(VolumeValue, 0.0f, 1.0f);
+
+	if (IsValid(UIAudioComp))
+	{
+		UIAudioComp->SetVolumeMultiplier(EffectVolume);
+
+		if (FMath::IsNearlyZero(EffectVolume))
+		{
+			UIAudioComp->SetPaused(true);
+			return;
+		}
+
+		if (UIAudioComp->bIsPaused)
+		{
+			UIAudioComp->SetPaused(false);
+		}
+	}
+}
+
+void USLSoundSubsystem::CheckValidOfSoundSource(ESLUISoundType SoundType)
+{
+	/*if (UISoundMap.Contains(SoundType))
+	{
+		if (IsValid(UISoundMap[SoundType]))
+		{
+			return;
+		}
+	}
+
+	CheckValidOfSoundSettings();
+	checkf(UISettings->WidgetSoundMap.Contains(SoundType), TEXT("Widget Sound Map is not contains soundtype"));
+
+	USoundBase* SoundSource = UISettings->WidgetSoundMap[SoundType].LoadSynchronous();
+	checkf(IsValid(SoundSource), TEXT("SoundSource is invalid"));
+
+	UISoundMap.Add(SoundType, SoundSource);*/
+}
+
+void USLSoundSubsystem::CheckValidOfSoundDataAsset()
+{
+	USLUISubsystem* UISubsystem = GetGameInstance()->GetSubsystem<USLUISubsystem>();
+	checkf(IsValid(UISubsystem), TEXT("UI Subsystem is invalid"));
+
+	ESLChapterType CurrentChapter = UISubsystem->GetCurrentChapter();
+
+	if (PossessChapter == CurrentChapter &&
+		IsValid(SoundDataAsset))
+	{
+		return;
+	}
+
+	CheckValidOfSoundSettings();
+	checkf(SoundSettings->ChapterSoundMap.Contains(CurrentChapter), TEXT("Sound Map is not contains CurrentChapter Sound Data"));
+	SoundDataAsset = SoundSettings->ChapterSoundMap[CurrentChapter].LoadSynchronous();
+	PossessChapter = CurrentChapter;
+}
+
+void USLSoundSubsystem::CheckValidOfSoundSettings()
+{
+	if (IsValid(SoundSettings))
+	{
+		return;
+	}
+
+	SoundSettings = GetDefault<USLSoundSettings>();
+	checkf(IsValid(SoundSettings), TEXT("Sound Settings is invalid"));
+}

--- a/Source/StillLoading/SubSystem/SLSoundSubsystem.h
+++ b/Source/StillLoading/SubSystem/SLSoundSubsystem.h
@@ -1,0 +1,51 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "SubSystem/SLSoundTypes.h"
+#include "UI/SLUITypes.h"
+#include "SLSoundSubsystem.generated.h"
+
+class USLSoundSettings;
+class USLSoundDataAsset;
+
+UCLASS()
+class STILLLOADING_API USLSoundSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+	
+public:
+	void PlayUISound(ESLUISoundType SoundType);
+	void StopUISound();
+
+	void PlayBgmSound(ESLBgmSoundType SoundType);
+	void StopBgmSound();
+
+	void SetBgmVolume(float VolumeValue);
+	void SetEffectVolume(float VolumeValue);
+
+private:
+	void CheckValidOfSoundSource(ESLUISoundType SoundType);
+	void CheckValidOfSoundDataAsset();
+	void CheckValidOfSoundSettings();
+
+private:
+	UPROPERTY()
+	const USLSoundSettings* SoundSettings = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<USLSoundDataAsset> SoundDataAsset = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<UAudioComponent> BgmAudioComp = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<UAudioComponent> UIAudioComp = nullptr;
+
+	ESLChapterType PossessChapter = ESLChapterType::EC_None;
+
+	float BgmVolume = 0.0f;
+	float EffectVolume = 0.0f;
+};

--- a/Source/StillLoading/SubSystem/SLSoundTypes.cpp
+++ b/Source/StillLoading/SubSystem/SLSoundTypes.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SubSystem/SLSoundTypes.h"
+

--- a/Source/StillLoading/SubSystem/SLSoundTypes.h
+++ b/Source/StillLoading/SubSystem/SLSoundTypes.h
@@ -1,0 +1,43 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "SLSoundTypes.generated.h"
+
+UENUM(BlueprintType)
+enum class ESLBgmSoundType : uint8
+{
+	EBS_None = 0,
+	EBS_Intro,
+	EBS_Title,
+	EBS_Battle,
+	EBS_Mini1,
+	EBS_Mini2,
+	EBS_Mini3,
+	EBS_Mini4,
+	EBS_Mini5,
+	EBS_DebugRoom,
+	EBS_BossBattle,
+	EBS_Ending
+};
+
+UENUM(BlueprintType)
+enum class ESLUISoundType : uint8
+{
+	EUS_None = 0,
+	EUS_Click,
+	EUS_Hover,
+	EUS_Open,
+	EUS_Close,
+	EUS_Notify,
+	EUS_Talk
+};
+
+UCLASS()
+class STILLLOADING_API USLSoundTypes : public UObject
+{
+	GENERATED_BODY()
+	
+};

--- a/Source/StillLoading/SubSystem/SLUserDataSubsystem.cpp
+++ b/Source/StillLoading/SubSystem/SLUserDataSubsystem.cpp
@@ -7,6 +7,7 @@
 #include "UI/SLUISubsystem.h"
 #include "SubSystem/SLTextPoolSubsystem.h"
 #include "SubSystem/SLUserDataSettings.h"
+#include "SubSystem/SLSoundSubsystem.h"
 #include "SaveLoad/SLSaveGameSubsystem.h"
 #include "InputMappingContext.h"
 #include "SaveLoad/SLSaveDataStructs.h"
@@ -151,6 +152,7 @@ void USLUserDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Collection.InitializeDependency<USLUISubsystem>();
 	Collection.InitializeDependency<USLTextPoolSubsystem>();
+	Collection.InitializeDependency<USLSoundSubsystem>();
 
 	Super::Initialize(Collection);
 
@@ -166,13 +168,16 @@ void USLUserDataSubsystem::ApplyLanguageMode()
 
 void USLUserDataSubsystem::ApplyBgmVolume()
 {
-	// TODO : Apply Bgm Volume To Bgm Audio Component
+	CheckValidOfSoundSubsystem();
+	SoundSubsystem->SetBgmVolume(BgmVolume);
 }
 
 void USLUserDataSubsystem::ApplyEffectVolume()
 {
-	CheckValidOfUISubsystem();
-	UISubsystem->SetEffectVolume(EffectVolume);
+	CheckValidOfSoundSubsystem();
+	SoundSubsystem->SetEffectVolume(EffectVolume);
+	/*CheckValidOfUISubsystem();
+	UISubsystem->SetEffectVolume(EffectVolume);*/
 }
 
 void USLUserDataSubsystem::ApplyResolution()
@@ -329,6 +334,17 @@ void USLUserDataSubsystem::CheckValidOfTextPoolSubsystem()
 
 	TextPoolSubsystem = GetGameInstance()->GetSubsystem<USLTextPoolSubsystem>();
 	checkf(IsValid(TextPoolSubsystem), TEXT("TextPool Subsystem is invalid"));
+}
+
+void USLUserDataSubsystem::CheckValidOfSoundSubsystem()
+{
+	if (IsValid(SoundSubsystem))
+	{
+		return;
+	}
+
+	SoundSubsystem = GetGameInstance()->GetSubsystem<USLSoundSubsystem>();
+	checkf(IsValid(SoundSubsystem), TEXT("Sound Subsystem is invalid"));
 }
 
 void USLUserDataSubsystem::CheckValidOfUserDataSettings()

--- a/Source/StillLoading/SubSystem/SLUserDataSubsystem.h
+++ b/Source/StillLoading/SubSystem/SLUserDataSubsystem.h
@@ -15,6 +15,7 @@ class UGameUserSettings;
 class URendererSettings;
 class USLUISubsystem;
 class USLTextPoolSubsystem;
+class USLSoundSubsystem;
 struct FWidgetSaveData;
 
 UCLASS()
@@ -62,6 +63,7 @@ private:
 	void CheckValidOfRendererSettings();
 	void CheckValidOfUISubsystem();
 	void CheckValidOfTextPoolSubsystem();
+	void CheckValidOfSoundSubsystem();
 	void CheckValidOfUserDataSettings();
 
 private:
@@ -79,6 +81,9 @@ private:
 
 	UPROPERTY()
 	TObjectPtr<USLTextPoolSubsystem> TextPoolSubsystem = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<USLSoundSubsystem> SoundSubsystem = nullptr;
 
 	UPROPERTY()
 	TObjectPtr<UInputMappingContext> PlayerIMC = nullptr;

--- a/Source/StillLoading/UI/SLUISettings.h
+++ b/Source/StillLoading/UI/SLUISettings.h
@@ -20,7 +20,4 @@ public:
 
 	UPROPERTY(EditAnywhere, Config, Category = "WidgetData")
 	TSoftObjectPtr<UDataAsset> WidgetPublicDataAsset = nullptr;
-
-	UPROPERTY(EditAnywhere, Config, Category = "SFXData")
-	TMap<ESLUISoundType, TSoftObjectPtr<USoundBase>> WidgetSoundMap;
 };

--- a/Source/StillLoading/UI/SLUISubsystem.cpp
+++ b/Source/StillLoading/UI/SLUISubsystem.cpp
@@ -148,30 +148,6 @@ void USLUISubsystem::RemoveAllAdditveWidget()
 	SetInputModeAndCursor();
 }
 
-void USLUISubsystem::PlayUISound(ESLUISoundType SoundType)
-{
-	CheckValidOfSoundSource(SoundType);
-
-	if (!IsValid(AudioComp))
-	{
-		AudioComp = UGameplayStatics::CreateSound2D(GetGameInstance(), UISoundMap[SoundType], EffectVolume);
-		AudioComp->bAutoDestroy = false;
-	}
-
-	StopUISound();
-
-	AudioComp->SetSound(UISoundMap[SoundType]);
-	AudioComp->Play();
-}
-
-void USLUISubsystem::StopUISound()
-{
-	if (IsValid(AudioComp) && AudioComp->IsPlaying())
-	{
-		AudioComp->Stop();
-	}
-}
-
 const ESLChapterType USLUISubsystem::GetCurrentChapter() const
 {
 	return WidgetActivateBuffer.CurrentChapter;
@@ -227,25 +203,6 @@ void USLUISubsystem::CheckValidOfUISettings()
 
 	UISettings = GetDefault<USLUISettings>();
 	checkf(IsValid(UISettings), TEXT("UI Settings is invalid"));
-}
-
-void USLUISubsystem::CheckValidOfSoundSource(ESLUISoundType SoundType)
-{
-	if (UISoundMap.Contains(SoundType))
-	{
-		if (IsValid(UISoundMap[SoundType]))
-		{
-			return;
-		}
-	}
-
-	CheckValidOfUISettings();
-	checkf(UISettings->WidgetSoundMap.Contains(SoundType), TEXT("Widget Sound Map is not contains soundtype"));
-
-	USoundBase* SoundSource = UISettings->WidgetSoundMap[SoundType].LoadSynchronous();
-	checkf(IsValid(SoundSource), TEXT("SoundSource is invalid"));
-
-	UISoundMap.Add(SoundType, SoundSource);
 }
 
 void USLUISubsystem::CheckValidOfWidgetDataAsset()

--- a/Source/StillLoading/UI/SLUISubsystem.h
+++ b/Source/StillLoading/UI/SLUISubsystem.h
@@ -35,9 +35,6 @@ public:
 	void RemoveCurrentAdditiveWidget(ESLAdditiveWidgetType WidgetType);
 	void RemoveAllAdditveWidget();
 
-	void PlayUISound(ESLUISoundType SoundType);
-	void StopUISound();
-	
 	const ESLChapterType GetCurrentChapter() const; //
 	UDataAsset* GetPublicImageData();
 	//temp
@@ -50,8 +47,6 @@ private:
 
 	void CheckValidOfAdditiveWidget(ESLAdditiveWidgetType WidgetType);
 	void CheckValidOfUISettings();
-
-	void CheckValidOfSoundSource(ESLUISoundType SoundType);
 	void CheckValidOfWidgetDataAsset();
 
 private:
@@ -60,9 +55,6 @@ private:
 
 	UPROPERTY()
 	TMap<ESLAdditiveWidgetType, USLAdditiveWidget*> AdditiveWidgetMap;
-
-	UPROPERTY()
-	TMap<ESLUISoundType, USoundBase*> UISoundMap;
 
 	UPROPERTY()
 	TArray<USLAdditiveWidget*> ActiveAdditiveWidgets;

--- a/Source/StillLoading/UI/SLUITypes.h
+++ b/Source/StillLoading/UI/SLUITypes.h
@@ -19,17 +19,6 @@ enum class ESLAdditiveWidgetType : uint8
 };
 
 UENUM(BlueprintType)
-enum class ESLUISoundType : uint8
-{
-	EUS_None = 0,
-	EUS_Click,
-	EUS_Hover,
-	EUS_Open,
-	EUS_Close,
-	EUS_Notify
-};
-
-UENUM(BlueprintType)
 enum class ESLChapterType : uint8
 {
 	EC_None = 0,

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SLBaseTextPrintWidget.cpp
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SLBaseTextPrintWidget.cpp
@@ -94,6 +94,8 @@ void USLBaseTextPrintWidget::PrintTalkText()
 	}
 
 	GetWorld()->GetTimerManager().SetTimer(TextPrintTimer, this, &ThisClass::PrintTalkText, NextPrintTime, false);
+
+	PlayUISound(ESLUISoundType::EUS_Talk);
 }
 
 void USLBaseTextPrintWidget::ChangeTargetText()

--- a/Source/StillLoading/UI/Widget/SLBaseWidget.cpp
+++ b/Source/StillLoading/UI/Widget/SLBaseWidget.cpp
@@ -4,6 +4,7 @@
 #include "UI/Widget/SLBaseWidget.h"
 #include "UI/SLUISubsystem.h"
 #include "SubSystem/SLTextPoolSubsystem.h"
+#include "SubSystem/SLSoundSubsystem.h"
 #include "UI/Struct/SLWidgetActivateBuffer.h"
 #include "Animation/WidgetAnimation.h"
 #include "UI/Widget/SLWidgetImageDataAsset.h"
@@ -207,8 +208,8 @@ bool USLBaseWidget::ApplyOtherImage()
 
 void USLBaseWidget::PlayUISound(ESLUISoundType SoundType)
 {
-	CheckValidOfUISubsystem();
-	UISubsystem->PlayUISound(SoundType);
+	CheckValidOfSoundSubsystem();
+	SoundSubsystem->PlayUISound(SoundType);
 }
 
 void USLBaseWidget::CheckValidOfUISubsystem()
@@ -232,4 +233,15 @@ void USLBaseWidget::CheckValidOfTextPoolSubsystem()
 
 	TextPoolSubsystem = GetGameInstance()->GetSubsystem<USLTextPoolSubsystem>();
 	checkf(IsValid(TextPoolSubsystem), TEXT("TextPool Subsystem is invalid"));
+}
+
+void USLBaseWidget::CheckValidOfSoundSubsystem()
+{
+	if (IsValid(SoundSubsystem))
+	{
+		return;
+	}
+
+	SoundSubsystem = GetGameInstance()->GetSubsystem<USLSoundSubsystem>();
+	checkf(IsValid(SoundSubsystem), TEXT("Sound Subsystem is invalid"));
 }

--- a/Source/StillLoading/UI/Widget/SLBaseWidget.h
+++ b/Source/StillLoading/UI/Widget/SLBaseWidget.h
@@ -5,11 +5,13 @@
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
 #include "UI/SLUITypes.h"
+#include "SubSystem/SLSoundTypes.h"
 #include "SubSystem/SLTextPoolTypes.h"
 #include "SLBaseWidget.generated.h"
 
 class USLUISubsystem;
 class USLTextPoolSubsystem;
+class USLSoundSubsystem;
 struct FSLWidgetActivateBuffer;
 
 UCLASS()
@@ -58,6 +60,7 @@ protected:
 
 	void CheckValidOfUISubsystem();
 	void CheckValidOfTextPoolSubsystem();
+	void CheckValidOfSoundSubsystem();
 
 protected:
 	UPROPERTY()
@@ -65,6 +68,9 @@ protected:
 
 	UPROPERTY()
 	TObjectPtr<USLTextPoolSubsystem> TextPoolSubsystem = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<USLSoundSubsystem> SoundSubsystem = nullptr;
 
 	UPROPERTY()
 	TObjectPtr<UWidgetAnimation> OpenAnim = nullptr;


### PR DESCRIPTION
…s. [Fix] SLUISubsystem, SLBaseWidget. [Update] SLBaseTextPrintWidget

공통으로 사용되는 사운드 관리할 SoundSubsystem 구현
- UISFXSound
- BgmSound

기존에 UISubsystem에서 UISound를 출력하던 기능 분리, 이전
UserDataSubsystem에서 이펙트 볼륨 값을 UISubsystem에 전달하던 기능 변경
UserDataSubsystem에서 배경 볼륨 값을 SoundSubsystem에 전달하는 기능 추가

대화 출력 시 한 글자마다 소리 출력하는 기능 추가

SoundSubsystem에 사용될 DataAsset들 생성,
Intro 챕터에 대한 사운드를 임시로 기본 사운드 할당

사운드가 출력되는 것 테스트 완료