### PR TITLE
[Add] LevelTransferSubsystem. [Fix] SoundSubsystem, UISubsystem, Widgets. [Update]SaveSubsystem

### DIFF
--- a/Config/DefaultLevelSetting.ini
+++ b/Config/DefaultLevelSetting.ini
@@ -1,0 +1,3 @@
+[/Script/StillLoading.SLLevelTransferSettings]
+ChapterLevelDataMap=((EC_Intro, "/Game/StillLoading/LevelData/DA_Ch0LevelData.DA_Ch0LevelData"),(EC_Chapter2D, "/Game/StillLoading/LevelData/DA_Ch1LevelData.DA_Ch1LevelData"),(EC_Chapter2_5D, "/Game/StillLoading/LevelData/DA_Ch2LevelData.DA_Ch2LevelData"),(EC_Chapter3D, "/Game/StillLoading/LevelData/DA_Ch3LevelData.DA_Ch3LevelData"),(EC_ChapterHighQuality, "/Game/StillLoading/LevelData/DA_Ch4LevelData.DA_Ch4LevelData"))
+

--- a/Content/StillLoading/LevelData/DA_Ch0LevelData.uasset
+++ b/Content/StillLoading/LevelData/DA_Ch0LevelData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b70f96b4b8d241717303fbf130f77eaee9fa83af4d32bf3f2dd7657c6429e09
+size 2579

--- a/Content/StillLoading/LevelData/DA_Ch1LevelData.uasset
+++ b/Content/StillLoading/LevelData/DA_Ch1LevelData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:196751686f3fc39d5b7deb08c86bb55f172084d2c7b1ded4aff172990f32f8e1
+size 1417

--- a/Content/StillLoading/LevelData/DA_Ch2LevelData.uasset
+++ b/Content/StillLoading/LevelData/DA_Ch2LevelData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4af6500c7350cfb9853c42da18c109a426a6886e62467f1327df66210cd44ad
+size 1417

--- a/Content/StillLoading/LevelData/DA_Ch3LevelData.uasset
+++ b/Content/StillLoading/LevelData/DA_Ch3LevelData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10bc461aef5d4b7d0cac34be4c372f6aa4ff1f62b4aad48f7398d418a116199c
+size 1417

--- a/Content/StillLoading/LevelData/DA_Ch4LevelData.uasset
+++ b/Content/StillLoading/LevelData/DA_Ch4LevelData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43ae6aa23690f2526af5172984421a82204e4b66ee8a1651641244e32e5cce73
+size 1417

--- a/Content/StillLoading/UI/DataAssets/DA_MapListPrivateData.uasset
+++ b/Content/StillLoading/UI/DataAssets/DA_MapListPrivateData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2146476e1a9dffd9266b14f859cc8d08207686191faacff76b5bf0ccf0fba7f
-size 8549
+oid sha256:8869822730ca95bb8a4c65774af69fd5470e2f97b40854544c292d119ae523a0
+size 9932

--- a/Content/StillLoading/UI/Widget/LevelWidget/WBP_SLInGameWidget.uasset
+++ b/Content/StillLoading/UI/Widget/LevelWidget/WBP_SLInGameWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8e52ef77fe9ca13acbe45b01e4ec8badf74895a862f6f8fad6d856bb3a7ad45
-size 213201
+oid sha256:9a04e26c444b2606d2f6ae3ff38871d221ff6171bce6bf2f03484419837c6916
+size 213021

--- a/Source/StillLoading/SaveLoad/SLSaveGame.cpp
+++ b/Source/StillLoading/SaveLoad/SLSaveGame.cpp
@@ -6,6 +6,4 @@
 USLSaveGame::USLSaveGame()
 {
 	CurrentMiniGameLevel = 0;
-	CurrentChapter = 0;
-
 }

--- a/Source/StillLoading/SaveLoad/SLSaveGame.h
+++ b/Source/StillLoading/SaveLoad/SLSaveGame.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/SaveGame.h"
 #include "SLSaveDataStructs.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "SLSaveGame.generated.h"
 
 
@@ -24,8 +25,8 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite) //테스트용 임시 변수
 	int CurrentMiniGameLevel;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite) //테스트용 임시 변수
-	int CurrentChapter;
+	UPROPERTY()
+	ESLChapterType CurrentChapter = ESLChapterType::EC_Intro;
 
 	UPROPERTY()
 	FWidgetSaveData WidgetSaveData;

--- a/Source/StillLoading/SaveLoad/SLSaveGameSubsystem.cpp
+++ b/Source/StillLoading/SaveLoad/SLSaveGameSubsystem.cpp
@@ -4,16 +4,14 @@
 #include "SaveLoad/SLSaveGameSubsystem.h"
 #include "Kismet/GameplayStatics.h"
 #include "SubSystem/SLUserDataSubsystem.h"
+#include "SubSystem/SLLevelTransferSubsystem.h"
 #include "SaveLoad/SLSaveGame.h"
-
-
 
 void USLSaveGameSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
     Collection.InitializeDependency<USLUserDataSubsystem>();
     Super::Initialize(Collection);
     LoadGame();
-
 }
 
 void USLSaveGameSubsystem::Deinitialize()
@@ -22,14 +20,13 @@ void USLSaveGameSubsystem::Deinitialize()
     SaveGame();
 }
 
-
-
 void USLSaveGameSubsystem::SaveGame()
 {
-
     check(CurrentSaveGame);
 
     SaveWidgetData();
+    SaveChapterData();
+    
     UGameplayStatics::SaveGameToSlot(CurrentSaveGame, SlotName, 0);
 
     UE_LOG(LogTemp, Warning, TEXT("Save Data"));
@@ -44,6 +41,7 @@ void USLSaveGameSubsystem::LoadGame()
         UE_LOG(LogTemp, Warning, TEXT("Data Load Succeed"));
         
         SendWidgetData();
+        SendChapterData();
     }
     else
     {
@@ -51,8 +49,6 @@ void USLSaveGameSubsystem::LoadGame()
         CurrentSaveGame = NewObject<USLSaveGame>();
         UGameplayStatics::SaveGameToSlot(CurrentSaveGame, SlotName, 0);
     }
-    
-
 }
 
 void USLSaveGameSubsystem::NewGame()
@@ -68,8 +64,6 @@ const FWidgetSaveData& USLSaveGameSubsystem::GetCurrentWidgetDataByRef() const
     check(CurrentSaveGame);
     return CurrentSaveGame->WidgetSaveData;
 }
-
-
 
 void USLSaveGameSubsystem::SaveWidgetData()
 { 
@@ -109,6 +103,19 @@ void USLSaveGameSubsystem::SendWidgetData()
     UserDataSubsystem->ApplyLoadedUserData(CurrentSaveGame->WidgetSaveData);
 }
 
+void USLSaveGameSubsystem::SaveChapterData()
+{
+    USLLevelTransferSubsystem* LevelSubsystem = GetGameInstance()->GetSubsystem<USLLevelTransferSubsystem>();
+    checkf(IsValid(LevelSubsystem), TEXT("Level Subsystem is invalid"));
 
+    CurrentSaveGame->CurrentChapter = LevelSubsystem->GetCurrentChapter();
+}
 
+void USLSaveGameSubsystem::SendChapterData()
+{
+    USLLevelTransferSubsystem* LevelSubsystem = GetGameInstance()->GetSubsystem<USLLevelTransferSubsystem>();
+    checkf(IsValid(LevelSubsystem), TEXT("Level Subsystem is invalid"));
 
+    checkf(IsValid(CurrentSaveGame), TEXT("Current Save Game is invalid"));
+    LevelSubsystem->SetCurrentChapter(CurrentSaveGame->CurrentChapter);
+}

--- a/Source/StillLoading/SaveLoad/SLSaveGameSubsystem.h
+++ b/Source/StillLoading/SaveLoad/SLSaveGameSubsystem.h
@@ -44,6 +44,12 @@ private:
     UFUNCTION()
     void SendWidgetData();
 
+    UFUNCTION()
+    void SaveChapterData();
+
+    UFUNCTION()
+    void SendChapterData();
+
 
     UPROPERTY()
     USLSaveGame* CurrentSaveGame;

--- a/Source/StillLoading/SubSystem/DataAssets/SLLevelDataAsset.cpp
+++ b/Source/StillLoading/SubSystem/DataAssets/SLLevelDataAsset.cpp
@@ -1,0 +1,10 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SubSystem/DataAssets/SLLevelDataAsset.h"
+
+const TSoftObjectPtr<UWorld> USLLevelDataAsset::GetLevelRef(ESLLevelNameType LevelNameType)
+{
+	checkf(LevelURLMap.Contains(LevelNameType), TEXT("Level Data Not Contains Level Type"));
+	return LevelURLMap[LevelNameType];
+}

--- a/Source/StillLoading/SubSystem/DataAssets/SLLevelDataAsset.h
+++ b/Source/StillLoading/SubSystem/DataAssets/SLLevelDataAsset.h
@@ -1,0 +1,21 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataAsset.h"
+#include "SubSystem/SLLevelTransferTypes.h"
+#include "SLLevelDataAsset.generated.h"
+
+UCLASS()
+class STILLLOADING_API USLLevelDataAsset : public UDataAsset
+{
+	GENERATED_BODY()
+	
+public:
+	const TSoftObjectPtr<UWorld> GetLevelRef(ESLLevelNameType LevelNameType);
+
+private:
+	UPROPERTY(EditAnywhere)
+	TMap<ESLLevelNameType, TSoftObjectPtr<UWorld>> LevelURLMap;
+};

--- a/Source/StillLoading/SubSystem/SLLevelTransferSettings.cpp
+++ b/Source/StillLoading/SubSystem/SLLevelTransferSettings.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SubSystem/SLLevelTransferSettings.h"
+

--- a/Source/StillLoading/SubSystem/SLLevelTransferSettings.h
+++ b/Source/StillLoading/SubSystem/SLLevelTransferSettings.h
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "SubSystem/SLLevelTransferTypes.h"
+#include "SLLevelTransferSettings.generated.h"
+
+class USLLevelDataAsset;
+
+UCLASS(Config = LevelSetting, DefaultConfig, meta = (DisplayName = "Level Trsnsfer Subsystem Settings"))
+class STILLLOADING_API USLLevelTransferSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+	
+public:
+	UPROPERTY(EditAnywhere, Config, Category = "LevelTransferData")
+	TMap<ESLChapterType, TSoftObjectPtr<USLLevelDataAsset>> ChapterLevelDataMap;
+};

--- a/Source/StillLoading/SubSystem/SLLevelTransferSubsystem.cpp
+++ b/Source/StillLoading/SubSystem/SLLevelTransferSubsystem.cpp
@@ -2,4 +2,73 @@
 
 
 #include "SubSystem/SLLevelTransferSubsystem.h"
+#include "SubSystem/SLLevelTransferSettings.h"
+#include "SubSystem/DataAssets/SLLevelDataAsset.h"
+#include "Kismet/GameplayStatics.h"
+#include "UI/SLUISubsystem.h"
 
+void USLLevelTransferSubsystem::OpenLevelByNameType(ESLLevelNameType LevelNameType, const FString& Option)
+{
+	CheckValidOfLevelDataAsset();
+
+	CurrentLevel = LevelNameType;
+	FString LevelURL = LevelDataAsset->GetLevelRef(LevelNameType).GetAssetName();
+	UGameplayStatics::OpenLevel(GetWorld(), (FName)LevelURL, true, Option);
+}
+
+const ESLLevelNameType USLLevelTransferSubsystem::GetCurrentLevelType() const
+{
+	return CurrentLevel;
+}
+
+void USLLevelTransferSubsystem::SetCurrentChapter(ESLChapterType ChapterType)
+{
+	CurrentChapter = ChapterType;
+
+	CheckValidOfUISubsystem();
+	UISubsystem->SetChapterToUI(ChapterType);
+
+	ChapterDelegate.Broadcast(ChapterType);
+}
+
+const ESLChapterType USLLevelTransferSubsystem::GetCurrentChapter() const
+{
+	return CurrentChapter;
+}
+
+void USLLevelTransferSubsystem::CheckValidOfLevelDataAsset()
+{
+	CheckValidOfLevelTransferSettings();
+
+	if (IsValid(LevelDataAsset) &&
+		DataChapter == CurrentChapter)
+	{
+		return;
+	}
+
+	DataChapter = CurrentChapter;
+	LevelDataAsset = LevelSettings->ChapterLevelDataMap[CurrentChapter].LoadSynchronous();
+	checkf(IsValid(LevelDataAsset), TEXT("Level Data Asset Load fail"));
+}
+
+void USLLevelTransferSubsystem::CheckValidOfLevelTransferSettings()
+{
+	if (IsValid(LevelSettings))
+	{
+		return;
+	}
+
+	LevelSettings = GetDefault<USLLevelTransferSettings>();
+	checkf(IsValid(LevelSettings), TEXT("Level Transfer Settings is invalid"));
+}
+
+void USLLevelTransferSubsystem::CheckValidOfUISubsystem()
+{
+	if (IsValid(UISubsystem))
+	{
+		return;
+	}
+
+	UISubsystem = GetGameInstance()->GetSubsystem<USLUISubsystem>();
+	checkf(IsValid(UISubsystem), TEXT("UISubsystem is invalid"));
+}

--- a/Source/StillLoading/SubSystem/SLLevelTransferSubsystem.h
+++ b/Source/StillLoading/SubSystem/SLLevelTransferSubsystem.h
@@ -4,14 +4,52 @@
 
 #include "CoreMinimal.h"
 #include "Subsystems/GameInstanceSubsystem.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "SLLevelTransferSubsystem.generated.h"
 
-/**
- * 
- */
+class USLLevelTransferSettings;
+class USLLevelDataAsset;
+class USLUISubsystem;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnChangedChapter, ESLChapterType, ChapterType);
+
 UCLASS()
 class STILLLOADING_API USLLevelTransferSubsystem : public UGameInstanceSubsystem
 {
 	GENERATED_BODY()
 	
+public:
+	UFUNCTION(BlueprintCallable)
+	void SetCurrentChapter(ESLChapterType ChapterType);
+
+	void OpenLevelByNameType(ESLLevelNameType LevelNameType, const FString& Option = ((FString)(L"")));
+
+	const ESLLevelNameType GetCurrentLevelType() const;
+	const ESLChapterType GetCurrentChapter() const;
+
+private:
+	void CheckValidOfLevelDataAsset();
+	void CheckValidOfLevelTransferSettings();
+	void CheckValidOfUISubsystem();
+
+public:
+	FOnChangedChapter ChapterDelegate;
+
+private:
+	UPROPERTY()
+	const USLLevelTransferSettings* LevelSettings = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<USLLevelDataAsset> LevelDataAsset = nullptr;
+
+	UPROPERTY()
+	TObjectPtr<USLUISubsystem> UISubsystem = nullptr;
+
+	UPROPERTY()
+	ESLLevelNameType CurrentLevel = ESLLevelNameType::ELN_None;
+
+	UPROPERTY()
+	ESLChapterType CurrentChapter = ESLChapterType::EC_Intro;
+
+	ESLChapterType DataChapter = ESLChapterType::EC_None;
 };

--- a/Source/StillLoading/SubSystem/SLLevelTransferTypes.cpp
+++ b/Source/StillLoading/SubSystem/SLLevelTransferTypes.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SubSystem/SLLevelTransferTypes.h"
+

--- a/Source/StillLoading/SubSystem/SLLevelTransferTypes.h
+++ b/Source/StillLoading/SubSystem/SLLevelTransferTypes.h
@@ -1,0 +1,42 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "SLLevelTransferTypes.generated.h"
+
+UENUM(BlueprintType)
+enum class ESLLevelNameType : uint8
+{
+	ELN_None = 0,
+	ELN_Intro,
+	ELN_Title,
+	ELN_MapList,
+	ELN_Mini1,
+	ELN_Mini2,
+	ELN_Mini3,
+	ELN_Mini4,
+	ELN_Mini5,
+	ELN_DebugRoom,
+	ELN_BossStage,
+	ELN_Ending
+};
+
+UENUM(BlueprintType)
+enum class ESLChapterType : uint8
+{
+	EC_None = 0,
+	EC_Intro,
+	EC_Chapter2D,
+	EC_Chapter2_5D,
+	EC_Chapter3D,
+	EC_ChapterHighQuality
+};
+
+UCLASS()
+class STILLLOADING_API USLLevelTransferTypes : public UObject
+{
+	GENERATED_BODY()
+	
+};

--- a/Source/StillLoading/SubSystem/SLSoundSettings.h
+++ b/Source/StillLoading/SubSystem/SLSoundSettings.h
@@ -4,7 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Engine/DeveloperSettings.h"
-#include "UI/SLUITypes.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "SLSoundSettings.generated.h"
 
 class USLSoundDataAsset;
@@ -16,7 +16,7 @@ class STILLLOADING_API USLSoundSettings : public UDeveloperSettings
 	
 public:
 	UPROPERTY(EditAnywhere, Config, Category = "SoundSourceData")
-	TMap < ESLChapterType, TSoftObjectPtr<USLSoundDataAsset>> ChapterSoundMap;
+	TMap <ESLChapterType, TSoftObjectPtr<USLSoundDataAsset>> ChapterSoundMap;
 
 	/*UPROPERTY(EditAnywhere, Config, Category = "SoundSourceData")
 	TSoftObjectPtr<USLSoundDataAsset> Chapter0SoundData = nullptr;

--- a/Source/StillLoading/SubSystem/SLSoundSubsystem.cpp
+++ b/Source/StillLoading/SubSystem/SLSoundSubsystem.cpp
@@ -3,7 +3,7 @@
 
 #include "SubSystem/SLSoundSubsystem.h"
 #include "SubSystem/SLSoundSettings.h"
-#include "UI/SLUISubsystem.h"
+#include "SubSystem/SLLevelTransferSubsystem.h"
 #include "Components/AudioComponent.h"
 #include "Kismet/GameplayStatics.h"
 #include "SubSystem/DataAssets/SLSoundDataAsset.h"
@@ -112,31 +112,12 @@ void USLSoundSubsystem::SetEffectVolume(float VolumeValue)
 	}
 }
 
-void USLSoundSubsystem::CheckValidOfSoundSource(ESLUISoundType SoundType)
-{
-	/*if (UISoundMap.Contains(SoundType))
-	{
-		if (IsValid(UISoundMap[SoundType]))
-		{
-			return;
-		}
-	}
-
-	CheckValidOfSoundSettings();
-	checkf(UISettings->WidgetSoundMap.Contains(SoundType), TEXT("Widget Sound Map is not contains soundtype"));
-
-	USoundBase* SoundSource = UISettings->WidgetSoundMap[SoundType].LoadSynchronous();
-	checkf(IsValid(SoundSource), TEXT("SoundSource is invalid"));
-
-	UISoundMap.Add(SoundType, SoundSource);*/
-}
-
 void USLSoundSubsystem::CheckValidOfSoundDataAsset()
 {
-	USLUISubsystem* UISubsystem = GetGameInstance()->GetSubsystem<USLUISubsystem>();
-	checkf(IsValid(UISubsystem), TEXT("UI Subsystem is invalid"));
+	USLLevelTransferSubsystem* LevelSubsystem = GetGameInstance()->GetSubsystem<USLLevelTransferSubsystem>();
+	checkf(IsValid(LevelSubsystem), TEXT("Level Subsystem is invalid"));
 
-	ESLChapterType CurrentChapter = UISubsystem->GetCurrentChapter();
+	ESLChapterType CurrentChapter = LevelSubsystem->GetCurrentChapter();
 
 	if (PossessChapter == CurrentChapter &&
 		IsValid(SoundDataAsset))

--- a/Source/StillLoading/SubSystem/SLSoundSubsystem.h
+++ b/Source/StillLoading/SubSystem/SLSoundSubsystem.h
@@ -5,7 +5,7 @@
 #include "CoreMinimal.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "SubSystem/SLSoundTypes.h"
-#include "UI/SLUITypes.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "SLSoundSubsystem.generated.h"
 
 class USLSoundSettings;
@@ -27,7 +27,6 @@ public:
 	void SetEffectVolume(float VolumeValue);
 
 private:
-	void CheckValidOfSoundSource(ESLUISoundType SoundType);
 	void CheckValidOfSoundDataAsset();
 	void CheckValidOfSoundSettings();
 

--- a/Source/StillLoading/UI/HUD/SLBaseHUD.cpp
+++ b/Source/StillLoading/UI/HUD/SLBaseHUD.cpp
@@ -3,9 +3,20 @@
 
 #include "UI/HUD/SLBaseHUD.h"
 #include "UI/Widget/LevelWidget/SLLevelWidget.h"
-#include "UI/Struct/SLWidgetActivateBuffer.h"
 #include "UI/SLUISubsystem.h"
+#include "SubSystem/SLLevelTransferSubsystem.h"
 
+
+void ASLBaseHUD::OnChangedCurrentChapter(ESLChapterType ChapterType)
+{
+	if (!IsValid(LevelWidgetObj))
+	{
+		return;
+	}
+
+	ActivateBuffer.CurrentChapter = ChapterType;
+	LevelWidgetObj->ActivateWidget(ActivateBuffer);
+}
 
 void ASLBaseHUD::BeginPlay()
 {
@@ -17,14 +28,16 @@ void ASLBaseHUD::BeginPlay()
 void ASLBaseHUD::OnStartedHUD()
 {
 	CheckValidOfUISubsystem();
-	CurrentChapter = UISubsystem->GetCurrentChapter();
-
 	CheckValidOfLevelWidget();
+
 	LevelWidgetObj->InitWidget(UISubsystem);
 	ApplyLevelWidgetInputMode();
 
-	FSLWidgetActivateBuffer ActivateBuffer;
-	ActivateBuffer.CurrentChapter = CurrentChapter;
+	USLLevelTransferSubsystem* LevelSubsystem = GetGameInstance()->GetSubsystem<USLLevelTransferSubsystem>();
+	checkf(IsValid(LevelSubsystem), TEXT("Level Subsystem is invalid"));
+
+	LevelSubsystem->ChapterDelegate.AddDynamic(this, &ThisClass::OnChangedCurrentChapter);
+	ActivateBuffer.CurrentChapter = LevelSubsystem->GetCurrentChapter();
 
 	if (!IsValid(ActivateBuffer.WidgetPrivateData))
 	{

--- a/Source/StillLoading/UI/HUD/SLBaseHUD.h
+++ b/Source/StillLoading/UI/HUD/SLBaseHUD.h
@@ -5,7 +5,9 @@
 #include "CoreMinimal.h"
 #include "GameFramework/HUD.h"
 #include "UI/SLUITypes.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "UI/Struct/SLLevelWidgetDataRow.h"
+#include "UI/Struct/SLWidgetActivateBuffer.h"
 #include "SLBaseHUD.generated.h"
 
 class USLLevelWidget;
@@ -17,6 +19,9 @@ class STILLLOADING_API ASLBaseHUD : public AHUD
 	GENERATED_BODY()
 
 protected:
+	UFUNCTION()
+	void OnChangedCurrentChapter(ESLChapterType ChapterType);
+
 	virtual void BeginPlay() override;
 	virtual void OnStartedHUD();
 	virtual void InitLevelWidget() {};
@@ -39,5 +44,6 @@ protected:
 	UPROPERTY()
 	TObjectPtr<USLUISubsystem> UISubsystem = nullptr;
 
-	ESLChapterType CurrentChapter = ESLChapterType::EC_Intro;
+	UPROPERTY()
+	FSLWidgetActivateBuffer ActivateBuffer;
 };

--- a/Source/StillLoading/UI/SLUISubsystem.cpp
+++ b/Source/StillLoading/UI/SLUISubsystem.cpp
@@ -3,9 +3,7 @@
 
 #include "UI/SLUISubsystem.h"
 #include "UI/SLUISettings.h"
-#include "Kismet/GameplayStatics.h"
 #include "UI/Widget/AdditiveWidget/SLAdditiveWidget.h"
-#include "Components/AudioComponent.h"
 
 void USLUISubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
@@ -74,7 +72,7 @@ void USLUISubsystem::ActivateFade(bool bIsFadeIn)
 {
 	WidgetActivateBuffer.bIsFade = bIsFadeIn;
 
-	AddAdditveWidget(ESLAdditiveWidgetType::EAW_FadeWidget);
+	AddAdditiveWidget(ESLAdditiveWidgetType::EAW_FadeWidget);
 }
 
 void USLUISubsystem::ActivateNotify(ESLGameMapType MapType, ESLNotifyType NotiType)
@@ -82,7 +80,7 @@ void USLUISubsystem::ActivateNotify(ESLGameMapType MapType, ESLNotifyType NotiTy
 	WidgetActivateBuffer.TargetMap = MapType;
 	WidgetActivateBuffer.TargetNotify = NotiType;
 
-	AddAdditveWidget(ESLAdditiveWidgetType::EAW_NotifyWidget);
+	AddAdditiveWidget(ESLAdditiveWidgetType::EAW_NotifyWidget);
 }
 
 void USLUISubsystem::ActivateStory(ESLStoryType TargetStoryType, int32 TargetIndex)
@@ -90,7 +88,7 @@ void USLUISubsystem::ActivateStory(ESLStoryType TargetStoryType, int32 TargetInd
 	WidgetActivateBuffer.TargetStory = TargetStoryType;
 	WidgetActivateBuffer.TargetIndex = TargetIndex;
 
-	AddAdditveWidget(ESLAdditiveWidgetType::EAW_StoryWidget);
+	AddAdditiveWidget(ESLAdditiveWidgetType::EAW_StoryWidget);
 }
 
 void USLUISubsystem::ActivateTalk(ESLTalkTargetType TalkTargetType, int32 TargetIndex)
@@ -98,10 +96,10 @@ void USLUISubsystem::ActivateTalk(ESLTalkTargetType TalkTargetType, int32 Target
 	WidgetActivateBuffer.TargetTalk = TalkTargetType;
 	WidgetActivateBuffer.TargetIndex = TargetIndex;
 
-	AddAdditveWidget(ESLAdditiveWidgetType::EAW_TalkWidget);
+	AddAdditiveWidget(ESLAdditiveWidgetType::EAW_TalkWidget);
 }
 
-void USLUISubsystem::AddAdditveWidget(ESLAdditiveWidgetType WidgetType)
+void USLUISubsystem::AddAdditiveWidget(ESLAdditiveWidgetType WidgetType)
 {
 	CheckValidOfAdditiveWidget(WidgetType);
 
@@ -148,25 +146,10 @@ void USLUISubsystem::RemoveAllAdditveWidget()
 	SetInputModeAndCursor();
 }
 
-const ESLChapterType USLUISubsystem::GetCurrentChapter() const
-{
-	return WidgetActivateBuffer.CurrentChapter;
-}
-
 UDataAsset* USLUISubsystem::GetPublicImageData()
 {
 	CheckValidOfWidgetDataAsset();
 	return WidgetActivateBuffer.WidgetPublicData;
-}
-
-void USLUISubsystem::SetEffectVolume(float VolumeValue)
-{
-	EffectVolume = FMath::Clamp(VolumeValue, 0.0f, 1.0f);
-
-	if (IsValid(AudioComp))
-	{
-		AudioComp->SetVolumeMultiplier(EffectVolume);
-	}
 }
 
 void USLUISubsystem::CheckValidOfAdditiveWidget(ESLAdditiveWidgetType WidgetType)

--- a/Source/StillLoading/UI/SLUISubsystem.h
+++ b/Source/StillLoading/UI/SLUISubsystem.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "UI/SLUITypes.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "UI/Struct/SLWidgetActivateBuffer.h"
 #include "SLUISubsystem.generated.h"
 
@@ -18,7 +19,6 @@ class STILLLOADING_API USLUISubsystem : public UGameInstanceSubsystem
 	GENERATED_BODY()
 	
 public:
-	UFUNCTION(BlueprintCallable)
 	void SetChapterToUI(ESLChapterType ChapterType);
 	void SetLevelInputMode(ESLInputModeType InputModeType, bool bIsVisibleMouseCursor);
 
@@ -31,14 +31,11 @@ public:
 	void ActivateTalk(ESLTalkTargetType TalkTargetType, int32 TargetIndex);
 
 	UFUNCTION(BlueprintCallable)
-	void AddAdditveWidget(ESLAdditiveWidgetType WidgetType);
+	void AddAdditiveWidget(ESLAdditiveWidgetType WidgetType);
 	void RemoveCurrentAdditiveWidget(ESLAdditiveWidgetType WidgetType);
 	void RemoveAllAdditveWidget();
 
-	const ESLChapterType GetCurrentChapter() const; //
 	UDataAsset* GetPublicImageData();
-	//temp
-	void SetEffectVolume(float VolumeValue);
 
 private:
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
@@ -60,14 +57,8 @@ private:
 	TArray<USLAdditiveWidget*> ActiveAdditiveWidgets;
 
 	UPROPERTY()
-	TObjectPtr<UAudioComponent> AudioComp = nullptr;
-
-	UPROPERTY()
 	FSLWidgetActivateBuffer WidgetActivateBuffer;
 
-	ESLChapterType CurrentChapter = ESLChapterType::EC_Intro;
 	ESLInputModeType CurrentLevelInputMode = ESLInputModeType::EIM_UIOnly;
-
 	bool bIsVisibleLevelCursor = true;
-	float EffectVolume = 1.0f;
 };

--- a/Source/StillLoading/UI/SLUITypes.h
+++ b/Source/StillLoading/UI/SLUITypes.h
@@ -19,17 +19,6 @@ enum class ESLAdditiveWidgetType : uint8
 };
 
 UENUM(BlueprintType)
-enum class ESLChapterType : uint8
-{
-	EC_None = 0,
-	EC_Intro,
-	EC_Chapter2D,
-	EC_Chapter2_5D,
-	EC_Chapter3D,
-	EC_ChapterHighQuality
-};
-
-UENUM(BlueprintType)
 enum class ESLInputModeType : uint8
 {
 	EIM_UIOnly = 0,

--- a/Source/StillLoading/UI/Struct/SLLevelWidgetDataRow.h
+++ b/Source/StillLoading/UI/Struct/SLLevelWidgetDataRow.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "UI/SLUITypes.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "SLLevelWidgetDataRow.generated.h"
 
 USTRUCT(BlueprintType)
@@ -13,7 +14,7 @@ struct STILLLOADING_API FSLMapListDataRow : public FTableRowBase
 
 public:
 	UPROPERTY(EditAnywhere)
-	FName MapName = "";
+	ESLLevelNameType MapName = ESLLevelNameType::ELN_None;
 
 	UPROPERTY(EditAnywhere)
 	int32 TargetRow = 0;

--- a/Source/StillLoading/UI/Struct/SLWidgetActivateBuffer.h
+++ b/Source/StillLoading/UI/Struct/SLWidgetActivateBuffer.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "UI/SLUITypes.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "SLWidgetActivateBuffer.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/StillLoading/UI/Struct/SLWidgetImageDataRow.h
+++ b/Source/StillLoading/UI/Struct/SLWidgetImageDataRow.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "UI/SLUITypes.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "SLWidgetImageDataRow.generated.h"
 
 

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SLOptionWidget.cpp
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SLOptionWidget.cpp
@@ -319,7 +319,7 @@ void USLOptionWidget::UpdateBrightness(float BrightnessValue)
 void USLOptionWidget::OnClickedKeySetting()
 {
 	CheckValidOfUISubsystem();
-	UISubsystem->AddAdditveWidget(ESLAdditiveWidgetType::EAW_KeySettingWidget);
+	UISubsystem->AddAdditiveWidget(ESLAdditiveWidgetType::EAW_KeySettingWidget);
 }
 
 void USLOptionWidget::OnClickedQuit()

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeyMappingWidget.cpp
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeyMappingWidget.cpp
@@ -59,6 +59,11 @@ const FName& USLKeyMappingWidget::GetTagIndex() const
 	return TagIndex;
 }
 
+const EInputActionType USLKeyMappingWidget::GetActionType() const
+{
+	return ActionType;
+}
+
 void USLKeyMappingWidget::OnClickedChangeKey()
 {
 	KeyDelegate.Broadcast(ActionType);

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeyMappingWidget.h
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeyMappingWidget.h
@@ -28,6 +28,7 @@ public:
 	void SetIsEnabledButton(bool bIsEnable);
 
 	const FName& GetTagIndex() const;
+	const EInputActionType GetActionType() const;
 
 private:
 	UFUNCTION()

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeySettingWidget.cpp
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeySettingWidget.cpp
@@ -86,14 +86,14 @@ void USLKeySettingWidget::ApplyTextData()
 		}
 	}
 
-	for (const TPair<EInputActionType, USLKeyMappingWidget*> ActionPair : ActionWidgetMap)
+	for (USLKeyMappingWidget* MappingWidget : MappingWidgets)
 	{
-		FName Index = ActionPair.Value->GetTagIndex();
+		FName Index = MappingWidget->GetTagIndex();
 
 		if (KeySettingTextMap.Contains(Index) &&
 			KeySettingTextMap[Index].ChapterTextMap.Contains(ESLChapterType::EC_Intro))
 		{
-			ActionPair.Value->UpdateTagText(KeySettingTextMap[Index].ChapterTextMap[ESLChapterType::EC_Intro]);
+			MappingWidget->UpdateTagText(KeySettingTextMap[Index].ChapterTextMap[ESLChapterType::EC_Intro]);
 		}
 	}
 }
@@ -135,9 +135,13 @@ void USLKeySettingWidget::UpdateKeyMapping(const FKey& InputKey)
 
 	if (UserDataSubsystem->UpdateMappingKey(TargetActionType, InputKey))
 	{
-		if (ActionWidgetMap.Contains(TargetActionType))
+		for (USLKeyMappingWidget* MappingWidget : MappingWidgets)
 		{
-			ActionWidgetMap[TargetActionType]->UpdateKeyText(InputKey.GetFName());
+			if (MappingWidget->GetActionType() == TargetActionType)
+			{
+				MappingWidget->UpdateKeyText(InputKey.GetFName());
+				break;
+			}
 		}
 	}
 
@@ -147,15 +151,15 @@ void USLKeySettingWidget::UpdateKeyMapping(const FKey& InputKey)
 
 void USLKeySettingWidget::SetFocusToTargetButton(EInputActionType TargetAction, bool bIsFocus)
 {
-	for (const TPair<EInputActionType, USLKeyMappingWidget*> KeyDataPair : ActionWidgetMap)
+	for (USLKeyMappingWidget* MappingWidget : MappingWidgets)
 	{
-		if (KeyDataPair.Key == TargetAction)
+		if (MappingWidget->GetActionType() == TargetAction)
 		{
-			KeyDataPair.Value->SetVisibilityButton(!bIsFocus);
+			MappingWidget->SetVisibilityButton(!bIsFocus);
 			continue;
 		}
 
-		KeyDataPair.Value->SetVisibilityButton(true);
+		MappingWidget->SetVisibilityButton(true);
 	}
 }
 
@@ -220,7 +224,8 @@ void USLKeySettingWidget::InitElementWidget()
 
 		NewMappingWidget->InitWidget(ActionType, KeyTagIndexMap[ActionType], ActionKeyMap[ActionType].Key.GetFName());
 		NewMappingWidget->KeyDelegate.AddDynamic(this, &ThisClass::OnClickedKeyDataButton);
-		ActionWidgetMap.Add(ActionType, NewMappingWidget);
+		MappingWidgets.Add(NewMappingWidget);
+		//ActionWidgetMap.Add(ActionType, NewMappingWidget);
 
 		KeySettingGrid->AddChildToGrid(NewMappingWidget, GridIndex / 2, GridIndex % 2);
 		++GridIndex;

--- a/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeySettingWidget.h
+++ b/Source/StillLoading/UI/Widget/AdditiveWidget/SubWidget/SLKeySettingWidget.h
@@ -56,7 +56,10 @@ private:
 	TObjectPtr<USLUserDataSubsystem> UserDataSubsystem = nullptr;
 
 	UPROPERTY()
-	TMap<EInputActionType, USLKeyMappingWidget*> ActionWidgetMap;
+	TArray<USLKeyMappingWidget*> MappingWidgets;
+
+	UPROPERTY()
+	TArray<USLKeyMappingWidget*> MappingWidgetArray;
 
 	UPROPERTY(Meta = (BindWidget))
 	TObjectPtr<UButton> CloseButton = nullptr;
@@ -67,7 +70,6 @@ private:
 	UPROPERTY(Meta = (BindWidget))
 	TObjectPtr<UImage> BackgroundImg = nullptr;
 
-	
 	UPROPERTY(Meta = (BindWidget))
 	TObjectPtr<UGridPanel> KeySettingGrid = nullptr;
 

--- a/Source/StillLoading/UI/Widget/LevelWidget/SLIntroWidget.cpp
+++ b/Source/StillLoading/UI/Widget/LevelWidget/SLIntroWidget.cpp
@@ -2,7 +2,6 @@
 
 
 #include "UI/Widget/LevelWidget/SLIntroWidget.h"
-#include "Kismet/GameplayStatics.h"
 
 void USLIntroWidget::InitWidget(USLUISubsystem* NewUISubsystem)
 {
@@ -32,5 +31,5 @@ void USLIntroWidget::OnEndedOpenAnim()
 
 void USLIntroWidget::OnEndedCloseAnim()
 {
-	UGameplayStatics::OpenLevel(GetWorld(), "TestTitleLevel");
+	MoveToLevelByType(ESLLevelNameType::ELN_Title);
 }

--- a/Source/StillLoading/UI/Widget/LevelWidget/SLLevelWidget.cpp
+++ b/Source/StillLoading/UI/Widget/LevelWidget/SLLevelWidget.cpp
@@ -22,5 +22,5 @@ void USLLevelWidget::ActivateWidget(const FSLWidgetActivateBuffer& WidgetActivat
 void USLLevelWidget::RequestAddedWidgetToUISubsystem(ESLAdditiveWidgetType TargetWidgetType)
 {
 	CheckValidOfUISubsystem();
-	UISubsystem->AddAdditveWidget(TargetWidgetType);
+	UISubsystem->AddAdditiveWidget(TargetWidgetType);
 }

--- a/Source/StillLoading/UI/Widget/LevelWidget/SLMapListWidget.cpp
+++ b/Source/StillLoading/UI/Widget/LevelWidget/SLMapListWidget.cpp
@@ -3,7 +3,6 @@
 
 #include "UI/Widget/LevelWidget/SLMapListWidget.h"
 #include "UI/Widget/LevelWidget/SubWidget/SLMapElementWidget.h"
-#include "Kismet/GameplayStatics.h"
 #include "Components/Button.h"
 #include "Components/Image.h"
 #include "Components/UniformGridPanel.h"
@@ -31,7 +30,7 @@ void USLMapListWidget::ActivateWidget(const FSLWidgetActivateBuffer& WidgetActiv
 		{
 			USLMapElementWidget* NewElement = CreateWidget<USLMapElementWidget>(this, MapElementWidgetClass);
 
-			NewElement->InitMapElement(MapData.Key);
+			NewElement->InitMapElement(MapData.Value.MapName);
 			NewElement->OnClickedMapElement.AddDynamic(this, &ThisClass::OnClickedElement);
 			//NewElement->SetIsEnabledButton(MapData.Value.DefaultEnabled);
 			NewElement->SetIsEnabled(MapData.Value.DefaultEnabled);
@@ -56,15 +55,9 @@ void USLMapListWidget::DeactivateWidget()
 	OnEndedCloseAnim();
 }
 
-void USLMapListWidget::OnClickedElement(ESLGameMapType TargetMapType)
+void USLMapListWidget::OnClickedElement(ESLLevelNameType TargetMapType)
 {
-	//checkf(ElementMap.Contains(TargetMapType), TEXT("Target Map not contains TargetMapType"));
-	//USLMapElementWidget* TargetElement = ElementMap[TargetMapType];
-
-	checkf(ElementMap.Contains(TargetMapType), TEXT("Element Data not contains TargetMapType"));
-	UE_LOG(LogTemp, Warning, TEXT("On Clicked %s"), *ElementMap[TargetMapType]->GetName());
-
-	UGameplayStatics::OpenLevel(GetWorld(), "TestInGameLevel");
+	MoveToLevelByType(TargetMapType);
 }
 
 void USLMapListWidget::ApplyFontData()

--- a/Source/StillLoading/UI/Widget/LevelWidget/SLMapListWidget.h
+++ b/Source/StillLoading/UI/Widget/LevelWidget/SLMapListWidget.h
@@ -23,7 +23,7 @@ public:
 
 protected:
 	UFUNCTION()
-	void OnClickedElement(ESLGameMapType TargetMapType);
+	void OnClickedElement(ESLLevelNameType TargetMapType);
 
 	virtual void ApplyFontData() override;
 	virtual bool ApplyBackgroundImage() override;

--- a/Source/StillLoading/UI/Widget/LevelWidget/SLTitleWidget.cpp
+++ b/Source/StillLoading/UI/Widget/LevelWidget/SLTitleWidget.cpp
@@ -113,13 +113,8 @@ bool USLTitleWidget::ApplyBorderImage()
 
 void USLTitleWidget::OnClickedStartButton()
 {
-	// TODO : Request Move To MapList Level
-	// Test Code : Add Map List Widget To Viewport
-	//CheckValidOfUISubsystem();
-	//UISubsystem->ActivateFade(false);
-
 	PlayUISound(ESLUISoundType::EUS_Click);
-	UGameplayStatics::OpenLevel(GetWorld(), "TestMapListLevel");
+	MoveToLevelByType(ESLLevelNameType::ELN_MapList);
 }
 
 void USLTitleWidget::OnClickedOptionButton()

--- a/Source/StillLoading/UI/Widget/LevelWidget/SubWidget/SLMapElementWidget.cpp
+++ b/Source/StillLoading/UI/Widget/LevelWidget/SubWidget/SLMapElementWidget.cpp
@@ -5,7 +5,7 @@
 #include "Components/Button.h"
 #include "Components/Image.h"
 
-void USLMapElementWidget::InitMapElement(ESLGameMapType NewType)
+void USLMapElementWidget::InitMapElement(ESLLevelNameType NewType)
 {
 	ElementType = NewType;
 	ElementButton->OnClicked.AddDynamic(this, &ThisClass::OnClickedMapElementButton);

--- a/Source/StillLoading/UI/Widget/LevelWidget/SubWidget/SLMapElementWidget.h
+++ b/Source/StillLoading/UI/Widget/LevelWidget/SubWidget/SLMapElementWidget.h
@@ -4,13 +4,13 @@
 
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
-#include "UI/SLUITypes.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "SLMapElementWidget.generated.h"
 
 class UButton;
 class UImage;
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnClickedMapElement, ESLGameMapType, MapElementName);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnClickedMapElement, ESLLevelNameType, MapElementName);
 
 UCLASS()
 class STILLLOADING_API USLMapElementWidget : public UUserWidget
@@ -18,7 +18,7 @@ class STILLLOADING_API USLMapElementWidget : public UUserWidget
 	GENERATED_BODY()
 	
 public:
-	void InitMapElement(ESLGameMapType NewType);
+	void InitMapElement(ESLLevelNameType NewType);
 	void SetMapElementImage(UTexture2D* ImageSource);
 	void SetIsEnabledButton(bool bIsEndabled);
 
@@ -37,5 +37,5 @@ private:
 	UPROPERTY(Meta = (BindWidget))
 	TObjectPtr<UImage> ElementImg = nullptr;
 
-	ESLGameMapType ElementType = ESLGameMapType::EGM_None;
+	ESLLevelNameType ElementType = ESLLevelNameType::ELN_None;
 };

--- a/Source/StillLoading/UI/Widget/SLBaseWidget.cpp
+++ b/Source/StillLoading/UI/Widget/SLBaseWidget.cpp
@@ -8,6 +8,7 @@
 #include "UI/Struct/SLWidgetActivateBuffer.h"
 #include "Animation/WidgetAnimation.h"
 #include "UI/Widget/SLWidgetImageDataAsset.h"
+#include "SubSystem/SLLevelTransferSubsystem.h"
 
 void USLBaseWidget::InitWidget(USLUISubsystem* NewUISubsystem)
 {
@@ -210,6 +211,14 @@ void USLBaseWidget::PlayUISound(ESLUISoundType SoundType)
 {
 	CheckValidOfSoundSubsystem();
 	SoundSubsystem->PlayUISound(SoundType);
+}
+
+void USLBaseWidget::MoveToLevelByType(ESLLevelNameType LevelType)
+{
+	USLLevelTransferSubsystem* LevelSubsystem = GetGameInstance()->GetSubsystem<USLLevelTransferSubsystem>();
+	checkf(IsValid(LevelSubsystem),TEXT("Level Subsystem is invalid"));
+
+	LevelSubsystem->OpenLevelByNameType(LevelType);
 }
 
 void USLBaseWidget::CheckValidOfUISubsystem()

--- a/Source/StillLoading/UI/Widget/SLBaseWidget.h
+++ b/Source/StillLoading/UI/Widget/SLBaseWidget.h
@@ -7,6 +7,7 @@
 #include "UI/SLUITypes.h"
 #include "SubSystem/SLSoundTypes.h"
 #include "SubSystem/SLTextPoolTypes.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "SLBaseWidget.generated.h"
 
 class USLUISubsystem;
@@ -57,6 +58,7 @@ protected:
 	virtual bool ApplyOtherImage();
 	
 	void PlayUISound(ESLUISoundType SoundType);
+	void MoveToLevelByType(ESLLevelNameType LevelType);
 
 	void CheckValidOfUISubsystem();
 	void CheckValidOfTextPoolSubsystem();

--- a/Source/StillLoading/UI/Widget/SLWidgetPrivateDataAsset.h
+++ b/Source/StillLoading/UI/Widget/SLWidgetPrivateDataAsset.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "Engine/DataAsset.h"
 #include "UI/SLUITypes.h"
+#include "SubSystem/SLLevelTransferTypes.h"
 #include "UI/Struct/SLLevelWidgetDataRow.h"
 #include "SLWidgetPrivateDataAsset.generated.h"
 


### PR DESCRIPTION
Level 이동과 현재 챕터 관리하는 LevelTransferSubsystem 생성 및 구현
LevelType 열거형에 따른 Level Asset 매핑 데이터 저장하는 DataAsset들 생성(챕터별)

기존 레벨 이동 기능을 임시로 만들어둔 위젯에서 해당 기능 수정
-> LevelTransferSubsystem에 이동 요청

챕터 데이터를 UISubsystem이 가지고 있는 구조에서 LevelTransferSubsystem이 가지는 구조로 변경
-> UISubsystem을 통해 챕터를 Get 하던 클래스의 수정
-> HUD는 생성되면 LevelTransferSubsystem에 Delegate를 Add하는 식으로 변경

SaveSubsystem에 현재 챕터를 저장/로드하는 기능 추가

임시 데이터를 통해 레벨 전환이 이루어지는 것 테스트 완료
챕터가 저장/로드 되는 것 테스트 완료