### PR TITLE
[fix] BP_SLPixelPerfectCamera...

### DIFF
--- a/Content/StillLoading/Character/BP_SL2DCharacter.uasset
+++ b/Content/StillLoading/Character/BP_SL2DCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff8a58cb6c947fbc85abef2c5c1fc4b89250aee13b85e8681d9a6f93fd13c34a
-size 62905
+oid sha256:5dff50cabec064f61d911f8ab605a74bd280a9ed761f4c324aad0b8fa9ef4430
+size 62885

--- a/Content/StillLoading/Character/Camera/BP_SLPixelPerfectCamera.uasset
+++ b/Content/StillLoading/Character/Camera/BP_SLPixelPerfectCamera.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a8890e6dc926e734b39903f0af0d6cc9ce7e69fe483f56da9c278693e0325f7
-size 34673
+oid sha256:ce066a372fdbe515225ac58366cd56cb1476b73711032f0c10bacfe4b9bdef90
+size 46241

--- a/Source/StillLoading/SubSystem/SLUserDataSubsystem.cpp
+++ b/Source/StillLoading/SubSystem/SLUserDataSubsystem.cpp
@@ -12,6 +12,16 @@
 #include "InputMappingContext.h"
 #include "SaveLoad/SLSaveDataStructs.h"
 
+float USLUserDataSubsystem::GetCurrentScreenWidthSize()
+{
+	return ScreenWidth;
+}
+
+float USLUserDataSubsystem::GetCurrentScreenHeightSize()
+{
+	return ScreenHeight;
+}
+
 void USLUserDataSubsystem::ApplyLoadedUserData(const FWidgetSaveData& LoadData)
 {
 	SetLanguage(LoadData.LanguageType);

--- a/Source/StillLoading/SubSystem/SLUserDataSubsystem.h
+++ b/Source/StillLoading/SubSystem/SLUserDataSubsystem.h
@@ -24,6 +24,11 @@ class STILLLOADING_API USLUserDataSubsystem : public UGameInstanceSubsystem
 	GENERATED_BODY()
 	
 public:
+	UFUNCTION(BlueprintCallable)
+	float GetCurrentScreenWidthSize();
+	UFUNCTION(BlueprintCallable)
+	float GetCurrentScreenHeightSize();
+
 	void ApplyLoadedUserData(const FWidgetSaveData& LoadData);
 	void ApplyDefaultUserData();
 
@@ -40,6 +45,7 @@ public:
 	float GetCurrentBrightness() const;
 	int32 GetCurrentWindowMode() const;
 	TPair<float, float> GetCurrentScreenSize();
+
 
 	bool UpdateMappingKey(EInputActionType TargetType, const FKey& KeyValue);
 	const TMap<EInputActionType, FEnhancedActionKeyMapping>& GetActionKeyMap();


### PR DESCRIPTION
[fix] BP_SLPixelPerfectCamera
      -> 카메라 이동 반경 수정
[update] SLUserDataSubsystem
         -> GetCurrentScreenWidthSize
            GetCurrentScreenHeightSize


이제 16:9 비율인 해상도에서는 보이는 화면 밖으로 넘어갈 시 카메라가 이동합니다.