### PR TITLE
[add] 진행 중 목표 관리 로직 및 데이터 구조 추가

### DIFF
--- a/Content/StillLoading/Interactable/Chapter1/GameMap2/NPC_Horseman.uasset
+++ b/Content/StillLoading/Interactable/Chapter1/GameMap2/NPC_Horseman.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:254273143f5a0b2b6ff29d12d66a2714e21fc4c0e264ee42012ce9b05ef73f51
+size 34617

--- a/Content/StillLoading/Maps/Chapter1/L_Ch1_GameMap2.umap
+++ b/Content/StillLoading/Maps/Chapter1/L_Ch1_GameMap2.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:00da9e4bf0c61eb6182689c9f63ee4a532226d3c93161dc484a82e8f04c6c578
-size 4587042
+oid sha256:8ef2ded480d092358cf9a3b3c1178889ad4e32563177447cc0dd4098ddc17dd5
+size 3242351

--- a/Content/StillLoading/Objective/Data/DA_Chapter1ObjectiveData.uasset
+++ b/Content/StillLoading/Objective/Data/DA_Chapter1ObjectiveData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d5928c129e9a02d0e1d4110cb861624d3d32b8019100aa06254bebce7d42c798
-size 2274
+oid sha256:6ecf1e9c271185adc6192baff1ed4cbe7adf50deb6dc22eb60ea7006db315654
+size 2121

--- a/Source/StillLoading/GameMode/SLGameMode.h
+++ b/Source/StillLoading/GameMode/SLGameMode.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "SLGameModeBase.h"
 #include "GameFramework/GameMode.h"
 #include "SLGameMode.generated.h"
 
@@ -10,7 +11,7 @@
  * 
  */
 UCLASS()
-class STILLLOADING_API ASLGameMode : public AGameModeBase
+class STILLLOADING_API ASLGameMode : public ASLGameModeBase
 {
 	GENERATED_BODY()
 

--- a/Source/StillLoading/GameMode/SLGameModeBase.cpp
+++ b/Source/StillLoading/GameMode/SLGameModeBase.cpp
@@ -5,10 +5,22 @@
 
 #include "GameState/SLGameStateBase.h"
 #include "Kismet/GameplayStatics.h"
+#include "Objective/SLObjectiveBase.h"
 
 ASLGameModeBase::ASLGameModeBase()
 {
 	GameStateClass = ASLGameStateBase::StaticClass();
+}
+
+void ASLGameModeBase::AddInProgressObjective(USLObjectiveBase* Objective)
+{
+	SLGameState->GetInProgressedObjectives().AddUnique(Objective);
+	OnInProgressObjectiveAdded.Broadcast(Objective);
+}
+
+USLObjectiveBase* ASLGameModeBase::GetPrimaryInProgressObjective()
+{
+	return SLGameState->GetInProgressedObjectives().Top();
 }
 
 void ASLGameModeBase::BeginPlay()
@@ -17,10 +29,21 @@ void ASLGameModeBase::BeginPlay()
 	SLGameState = Cast<ASLGameStateBase>(GameState);
 	checkf(SLGameState, TEXT("GameState is not ASLGameStateBase"));
 
-	
+	//TODO : 세이브 시스템으로부터 저장된 InProgressedObjective 가져와서 Top에 BroadCast 하기
 }
 
 void ASLGameModeBase::LoadGame()
 {
 	
+}
+
+void ASLGameModeBase::LoadInProgressObjectives()
+{
+	for (USLObjectiveBase* InProgressObjective : SLGameState->GetInProgressedObjectives())
+	{
+		if (InProgressObjective)
+		{
+			AddInProgressObjective(InProgressObjective);
+		}
+	}
 }

--- a/Source/StillLoading/GameMode/SLGameModeBase.h
+++ b/Source/StillLoading/GameMode/SLGameModeBase.h
@@ -7,7 +7,11 @@
 #include "SLGameModeBase.generated.h"
 
 
+class USLObjectiveBase;
 class ASLGameStateBase;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnInProgressObjectiveAdded, USLObjectiveBase*, Objective);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnInProgressObjectiveRemoved, USLObjectiveBase*, Objective);
 
 UCLASS()
 class STILLLOADING_API ASLGameModeBase : public AGameMode
@@ -16,11 +20,23 @@ class STILLLOADING_API ASLGameModeBase : public AGameMode
 
 public:
 	ASLGameModeBase();
+	UFUNCTION(BlueprintCallable)
+	void AddInProgressObjective(USLObjectiveBase* Objective);
+	UFUNCTION(BlueprintCallable)
+	USLObjectiveBase* GetPrimaryInProgressObjective();
+	
+	UPROPERTY(BlueprintAssignable)
+	FOnInProgressObjectiveAdded OnInProgressObjectiveAdded;
+	UPROPERTY(BlueprintAssignable)
+	FOnInProgressObjectiveRemoved OnInProgressObjectiveRemoved;
 	
 protected:
 	virtual void BeginPlay() override;
 	virtual void LoadGame();
 
 private:
-	TSoftObjectPtr<ASLGameStateBase> SLGameState;
+	void LoadInProgressObjectives();
+	
+	UPROPERTY()
+	TObjectPtr<ASLGameStateBase> SLGameState;
 };

--- a/Source/StillLoading/GameState/SLGameStateBase.cpp
+++ b/Source/StillLoading/GameState/SLGameStateBase.cpp
@@ -7,3 +7,14 @@ ASLGameStateBase::ASLGameStateBase()
 {
 	PrimaryActorTick.bCanEverTick = false;
 }
+
+TArray<TObjectPtr<USLObjectiveBase>>& ASLGameStateBase::GetInProgressedObjectives()
+{
+	return InProgressedObjectives;
+}
+
+void ASLGameStateBase::BeginPlay()
+{
+	Super::BeginPlay();
+
+}

--- a/Source/StillLoading/GameState/SLGameStateBase.h
+++ b/Source/StillLoading/GameState/SLGameStateBase.h
@@ -7,6 +7,8 @@
 #include "SLGameStateBase.generated.h"
 
 
+class USLObjectiveBase;
+
 UCLASS()
 class STILLLOADING_API ASLGameStateBase : public AGameState
 {
@@ -14,5 +16,12 @@ class STILLLOADING_API ASLGameStateBase : public AGameState
 
 public:
 	ASLGameStateBase();
+
+	TArray<TObjectPtr<USLObjectiveBase>>& GetInProgressedObjectives();
 	
+protected:
+	virtual void BeginPlay() override;
+
+private:
+	TArray<TObjectPtr<USLObjectiveBase>> InProgressedObjectives;
 };

--- a/Source/StillLoading/Objective/SLObjectiveSubsystem.cpp
+++ b/Source/StillLoading/Objective/SLObjectiveSubsystem.cpp
@@ -24,6 +24,22 @@ bool USLObjectiveSubsystem::IsObjectiveCompleted(const ESLChapterType Chapter, c
     return Objective->GetObjectiveState() == ESLObjectiveState::Complete;
 }
 
+TArray<USLObjectiveBase*> USLObjectiveSubsystem::GetInProgressedObejctives()
+{
+    TArray<USLObjectiveBase*> InProgressedObjectives;
+    for (const auto&[Chapter, ChapterData] : CachedChapterObjectiveDataMap)
+    {
+        for (const auto&[Name, Objective] : ChapterData.ChapterObjectiveMap)
+        {
+            if (Objective->GetObjectiveState() == ESLObjectiveState::InProgress)
+            {
+                InProgressedObjectives.Add(Objective);
+            }
+        }
+    }
+    return InProgressedObjectives;
+}
+
 void USLObjectiveSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
     Super::Initialize(Collection);

--- a/Source/StillLoading/Objective/SLObjectiveSubsystem.h
+++ b/Source/StillLoading/Objective/SLObjectiveSubsystem.h
@@ -28,6 +28,9 @@ public:
 	UFUNCTION(BlueprintCallable)
 	bool IsObjectiveCompleted(ESLChapterType Chapter, FName Name);
 
+	UFUNCTION(BlueprintCallable)
+	TArray<USLObjectiveBase*> GetInProgressedObejctives();
+	
 protected:
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	

--- a/Source/StillLoading/SaveLoad/SLSaveGame.h
+++ b/Source/StillLoading/SaveLoad/SLSaveGame.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/SaveGame.h"
 #include "SLSaveDataStructs.h"
+#include "Objective/SLObjectiveDataAsset.h"
 #include "SubSystem/SLLevelTransferTypes.h"
 #include "SLSaveGame.generated.h"
 
@@ -31,4 +32,9 @@ public:
 	UPROPERTY()
 	FWidgetSaveData WidgetSaveData;
 
+	UPROPERTY()
+	TMap<ESLChapterType, FSLObjectiveRuntimeData> ChapterObjectiveSaveData;
+	
+	UPROPERTY()
+	TArray<TObjectPtr<USLObjectiveBase>> InProgressedObjectiveSaveData;
 };


### PR DESCRIPTION
- `USLObjectiveSubsystem`에 진행 중인 목표 관련 기능 추가
  - `GetInProgressedObejctives` 메서드 추가
- `ASLGameModeBase` 및 `ASLGameStateBase`에 진행 중 목표 로직 추가
  - `AddInProgressObjective`, `GetPrimaryInProgressObjective` 메서드 구현
  - 진행 중 목표 추가/삭제 시 브로드캐스트 처리
- `SLSaveGame`에 진행 중 목표 데이터 저장/로드 구조 추가
- 관련 헤더 및 CPP 파일 업데이트
- L_Ch1_GameMap2 및 신규 NPC 에셋 추가 (NPC_Horseman.uasset)