### PR TITLE
[add] 진행 중 목표 우선순위 변경 및 브로드캐스트 로직 추가

### DIFF
--- a/Content/StillLoading/Interactable/Chapter1/GameMap4/NPC_Evacuee.uasset
+++ b/Content/StillLoading/Interactable/Chapter1/GameMap4/NPC_Evacuee.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82294416bbdc5bb2debdbc6520a03cf7cb0c32552e7d7c9fe22b6e0104248d5c
-size 59878
+oid sha256:1b5f22c3f9754abde90826e7ac80c8f66a259bbe29af2d4bbd8678d580fc0d13
+size 73189

--- a/Content/StillLoading/Maps/Chapter1/L_Ch1_GameMap1.umap
+++ b/Content/StillLoading/Maps/Chapter1/L_Ch1_GameMap1.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:582900caaf9be43a0182a7d749c66a59727b7dc9a561bb7aaafcf91a2954288d
-size 2611627
+oid sha256:7750ee1e8dc97dcd9d931a31ef1acc0b06edac09c8f0fedf5d087238da84fcea
+size 2625709

--- a/Content/StillLoading/Maps/Chapter1/L_Ch1_GameMap2.umap
+++ b/Content/StillLoading/Maps/Chapter1/L_Ch1_GameMap2.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:843242ef4c50623f86a5303121f7ae25024fefbf062c61706afa7248ad7eec3f
-size 3682989
+oid sha256:8aaad081946262cf519d8f7b19f3fc72cbab5b9050b02f963f068978e7fc6b24
+size 3691576

--- a/Content/StillLoading/Maps/Chapter1/L_Ch1_GameMap4.umap
+++ b/Content/StillLoading/Maps/Chapter1/L_Ch1_GameMap4.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4cd4a58fa636b8fba2729641adf3f97790e30576ddc7a8610ce757cab88c9471
-size 4678101
+oid sha256:2fbce5905d89a06b95f0ae4f7ff8e8a43fd8910e22f8a588d2a6730055b42c2f
+size 4682505

--- a/Content/StillLoading/UI/DataTables/TalkTextPool/DT_Ch1_TalkText_Kor.uasset
+++ b/Content/StillLoading/UI/DataTables/TalkTextPool/DT_Ch1_TalkText_Kor.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:422ab595ff628e89d113ad2118978089d3420efe1b739ec96e9dccee32382e53
-size 37915
+oid sha256:705bf539a75af42176c8d4629e581f284e05e68ee9897a933c6b7e567e5bfb18
+size 42189

--- a/Source/StillLoading/GameMode/SLGameModeBase.cpp
+++ b/Source/StillLoading/GameMode/SLGameModeBase.cpp
@@ -16,12 +16,19 @@ void ASLGameModeBase::AddInProgressObjective(USLObjectiveBase* Objective)
 {
 	SLGameState->GetInProgressedObjectives().AddUnique(Objective);
 	OnInProgressObjectiveAdded.Broadcast(Objective);
+	OnPrimaryInProgressObjectiveChanged.Broadcast(Objective);
 }
 
 void ASLGameModeBase::RemoveInProgressObjective(USLObjectiveBase* Objective)
 {
-	SLGameState->GetInProgressedObjectives().Remove(Objective);
+	TArray<TObjectPtr<USLObjectiveBase>>& InProgressedObjectives = SLGameState->GetInProgressedObjectives();
+	InProgressedObjectives.Remove(Objective);
 	OnInProgressObjectiveRemoved.Broadcast(Objective);
+
+	if (InProgressedObjectives.IsEmpty() == false)
+	{
+		OnPrimaryInProgressObjectiveChanged.Broadcast(InProgressedObjectives.Top());
+	}
 }
 
 USLObjectiveBase* ASLGameModeBase::GetPrimaryInProgressObjective()

--- a/Source/StillLoading/GameMode/SLGameModeBase.h
+++ b/Source/StillLoading/GameMode/SLGameModeBase.h
@@ -12,6 +12,7 @@ class ASLGameStateBase;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnInProgressObjectiveAdded, USLObjectiveBase*, Objective);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnInProgressObjectiveRemoved, USLObjectiveBase*, Objective);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnPrimaryInProgressObjectiveChanged, USLObjectiveBase*, Objective);
 
 UCLASS()
 class STILLLOADING_API ASLGameModeBase : public AGameMode
@@ -31,6 +32,8 @@ public:
 	FOnInProgressObjectiveAdded OnInProgressObjectiveAdded;
 	UPROPERTY(BlueprintAssignable)
 	FOnInProgressObjectiveRemoved OnInProgressObjectiveRemoved;
+	UPROPERTY(BlueprintAssignable)
+	FOnPrimaryInProgressObjectiveChanged OnPrimaryInProgressObjectiveChanged;
 	
 protected:
 	virtual void BeginPlay() override;

--- a/Source/StillLoading/Objective/SLObjectiveBase.cpp
+++ b/Source/StillLoading/Objective/SLObjectiveBase.cpp
@@ -24,6 +24,11 @@ void USLObjectiveBase::ObjectiveFail()
 
 void USLObjectiveBase::SetObjectiveState(const ESLObjectiveState InState)
 {
+	if (ObjectiveState == InState)
+	{
+		return;
+	}
+	
 	ObjectiveState = InState;
 	switch (InState)
 	{


### PR DESCRIPTION
- `ASLGameModeBase`에 진행 중 목표 변경 시 브로드캐스트(`OnPrimaryInProgressObjectiveChanged`) 로직 추가
- `RemoveInProgressObjective`에 비어 있지 않은 경우 우선순위 변경 처리 구현
- `USLObjectiveBase`에 동일 상태 변경 방지 로직 추가
- 관련 헤더 및 CPP 파일 업데이트
- 다수의 맵 및 에셋 데이터 갱신 (`DT_Ch1_TalkText_Kor`, `L_Ch1_GameMap1`, 등)