### PR TITLE
[update] 오브젝티브, 세이브/로드 시스템

### DIFF
--- a/Content/StillLoading/GameMode/BP_SLIntroGameMode.uasset
+++ b/Content/StillLoading/GameMode/BP_SLIntroGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d27bd845010bc3dc737b22649c27e5cc0cf2d0f11a3e4025d8dd4499ac5f20ae
-size 27499
+oid sha256:522dd328c7c87b1cd62dd0bb6bf4bd235013547152ba24c3d250febdc444c4c3
+size 17319

--- a/Content/StillLoading/Maps/L_Intro.umap
+++ b/Content/StillLoading/Maps/L_Intro.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9c7c975099bdf9e051805aff57ef6a7f84414e6db18294164393437cc788aa4
-size 9104
+oid sha256:52a7c8bb17ae5ea833578455bdc212a54565da1487105ad62252b6bba72dbea4
+size 40358

--- a/Source/StillLoading/Objective/SLObjectiveBase.cpp
+++ b/Source/StillLoading/Objective/SLObjectiveBase.cpp
@@ -4,6 +4,7 @@
 #include "SLObjectiveBase.h"
 
 #include "GameMode/SLGameModeBase.h"
+#include "SaveLoad/SLSaveDataStructs.h"
 
 void USLObjectiveBase::AddObjectiveProgress(const int32 Count)
 {

--- a/Source/StillLoading/Objective/SLObjectiveBase.h
+++ b/Source/StillLoading/Objective/SLObjectiveBase.h
@@ -5,6 +5,8 @@
 #include "CoreMinimal.h"
 #include "SLObjectiveBase.generated.h"
 
+struct FObjectiveSaveData;
+
 UENUM(BlueprintType)
 enum class ESLObjectiveState : uint8
 {
@@ -52,7 +54,7 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "Objective")
 	int32 GetObjectiveCompleteCount() const { return ObjectiveCompleteCount; }
-	
+
 public:
 	UPROPERTY(BlueprintAssignable, Category = "Objective Delegate")
 	FOnObjectiveStateChanged OnObjectiveStateChanged;

--- a/Source/StillLoading/Objective/SLObjectiveSubsystem.h
+++ b/Source/StillLoading/Objective/SLObjectiveSubsystem.h
@@ -11,6 +11,7 @@
  * 
  */
 
+enum class ESLObjectiveState : uint8;
 enum class ESLChapterType : uint8;
 class USLObjectiveDataAsset;
 class USLObjectiveDataSettings;
@@ -26,18 +27,17 @@ public:
 	USLObjectiveBase* GetObjective(ESLChapterType Chapter, FName Name);
 
 	UFUNCTION(BlueprintCallable)
-	bool IsObjectiveCompleted(ESLChapterType Chapter, FName Name);
+	ESLObjectiveState GetObjectiveState(ESLChapterType Chapter, FName Name);
 
 	UFUNCTION(BlueprintCallable)
-	TArray<USLObjectiveBase*> GetInProgressedObejctives();
-	
+	TArray<USLObjectiveBase*> GetInProgressedObjectives();
+
+	TMap<ESLChapterType, FSLObjectiveRuntimeData>& GetCachedObjectiveDataRef();
+
 protected:
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	
 private:
 	UPROPERTY()
-	const USLObjectiveDataSettings* ObjectiveDataSettings = nullptr;
-
-	UPROPERTY()
-	TMap<ESLChapterType, FSLObjectiveRuntimeData> CachedChapterObjectiveDataMap;
+	TMap<ESLChapterType, FSLObjectiveRuntimeData> CachedObjectiveData;
 };

--- a/Source/StillLoading/SaveLoad/SLSaveDataStructs.h
+++ b/Source/StillLoading/SaveLoad/SLSaveDataStructs.h
@@ -6,13 +6,16 @@
 #include "UI/SLUITypes.h"
 #include "SubSystem/SLTextPoolTypes.h"
 #include "Character/DynamicIMCComponent/SLDynamicIMCComponent.h"
+#include "Objective/SLObjectiveBase.h"
 #include "SLSaveDataStructs.generated.h"
 /**
  * 
  */
 
+enum class ESLChapterType : uint8;
+
 USTRUCT(BlueprintType)
-struct FWidgetSaveData
+struct FUserSaveData
 {
 	GENERATED_BODY()
 
@@ -44,3 +47,20 @@ struct FWidgetSaveData
 	float ScreenHeight = 1080.0f;
 };
 
+USTRUCT(BlueprintType)
+struct FObjectiveSaveData
+{
+	GENERATED_BODY()
+
+	UPROPERTY(SaveGame)
+	TMap<FName, ESLObjectiveState> ObjectiveSaveDataMap;
+};
+
+USTRUCT(BlueprintType)
+struct FChapterObjectiveSaveData
+{
+	GENERATED_BODY()
+
+	UPROPERTY(SaveGame)
+	TMap<ESLChapterType, FObjectiveSaveData> ChapterObjectiveSaveDataMap;
+};

--- a/Source/StillLoading/SaveLoad/SLSaveGame.h
+++ b/Source/StillLoading/SaveLoad/SLSaveGame.h
@@ -30,11 +30,12 @@ public:
 	ESLChapterType CurrentChapter = ESLChapterType::EC_Chapter0;
 
 	UPROPERTY()
-	FWidgetSaveData WidgetSaveData;
+	FUserSaveData UserSaveData;
+
+	// UPROPERTY()
+	// TMap<ESLChapterType, FSLObjectiveRuntimeData> ObjectiveSaveData;
 
 	UPROPERTY()
-	TMap<ESLChapterType, FSLObjectiveRuntimeData> ChapterObjectiveSaveData;
+	FChapterObjectiveSaveData ObjectiveSaveData;
 	
-	UPROPERTY()
-	TArray<TObjectPtr<USLObjectiveBase>> InProgressedObjectiveSaveData;
 };

--- a/Source/StillLoading/SaveLoad/SLSaveGameSubsystem.h
+++ b/Source/StillLoading/SaveLoad/SLSaveGameSubsystem.h
@@ -7,6 +7,8 @@
 #include "SLSaveDataStructs.h"
 #include "SLSaveGameSubsystem.generated.h"
 
+struct FSLObjectiveRuntimeData;
+enum class ESLChapterType : uint8;
 class USLSaveGame;
 
 UCLASS()
@@ -17,44 +19,28 @@ class STILLLOADING_API USLSaveGameSubsystem : public UGameInstanceSubsystem
 public:
 
     virtual void Initialize(FSubsystemCollectionBase& Collection) override;
-
     virtual void Deinitialize() override;
 
- 
     UFUNCTION(BlueprintCallable)
-    void SaveGame();
-
+    void SaveGameData();
     UFUNCTION(BlueprintCallable)
-    void LoadGame();
-
+    void LoadGameData();
     UFUNCTION(BlueprintCallable)
-    void NewGame();
-
-    UFUNCTION(BlueprintCallable)
-    USLSaveGame* GetCurrentSaveGame() const { return CurrentSaveGame; }
-
-    UFUNCTION()
-    const FWidgetSaveData& GetCurrentWidgetDataByRef() const;
-
+    void ResetGameData();
 
 private:
-    UFUNCTION()
+    void LoadObjectiveDefaultData();
+    
     void SaveWidgetData();
-
-    UFUNCTION()
-    void SendWidgetData(bool bIsFirstGame);
-
-    UFUNCTION()
     void SaveChapterData();
-
-    UFUNCTION()
+    void SaveObjectiveData();
+    
+    void SendWidgetData(bool bIsFirstGame);
     void SendChapterData();
-
-
-    UPROPERTY()
-    USLSaveGame* CurrentSaveGame;
+    void SendObjectiveData();
 
     UPROPERTY()
-    FString SlotName = FString(TEXT("SaveData"));
-
+    TObjectPtr<USLSaveGame> CurrentSaveData;
+    UPROPERTY()
+    FString SlotName = "SaveData";
 };

--- a/Source/StillLoading/SubSystem/SLLevelTransferSubsystem.cpp
+++ b/Source/StillLoading/SubSystem/SLLevelTransferSubsystem.cpp
@@ -5,6 +5,7 @@
 #include "SubSystem/SLLevelTransferSettings.h"
 #include "SubSystem/DataAssets/SLLevelDataAsset.h"
 #include "Kismet/GameplayStatics.h"
+#include "SaveLoad/SLSaveGameSubsystem.h"
 #include "UI/SLUISubsystem.h"
 #include "SubSystem/SLSoundSubsystem.h"
 #include "UI/HUD/SLBaseHUD.h"
@@ -57,6 +58,11 @@ void USLLevelTransferSubsystem::SetCurrentChapter(ESLChapterType ChapterType)
 	CheckValidOfUISubsystem();
 	UISubsystem->SetChapterToUI(ChapterType);
 
+	if (USLSaveGameSubsystem* SaveGameSubsystem = GetGameInstance()->GetSubsystem<USLSaveGameSubsystem>())
+	{
+		SaveGameSubsystem->SaveGameData();
+	}
+	
 	ChapterDelegate.Broadcast(ChapterType);
 }
 

--- a/Source/StillLoading/SubSystem/SLUserDataSubsystem.cpp
+++ b/Source/StillLoading/SubSystem/SLUserDataSubsystem.cpp
@@ -25,7 +25,7 @@ float USLUserDataSubsystem::GetCurrentScreenHeightSize()
 	return ScreenHeight;
 }
 
-void USLUserDataSubsystem::ApplyLoadedUserData(const FWidgetSaveData& LoadData)
+void USLUserDataSubsystem::ApplyLoadedUserData(const FUserSaveData& LoadData)
 {
 	SetLanguage(LoadData.LanguageType);
 	SetBgmVolume(LoadData.BgmVolume);

--- a/Source/StillLoading/SubSystem/SLUserDataSubsystem.h
+++ b/Source/StillLoading/SubSystem/SLUserDataSubsystem.h
@@ -16,7 +16,7 @@ class URendererSettings;
 class USLUISubsystem;
 class USLTextPoolSubsystem;
 class USLSoundSubsystem;
-struct FWidgetSaveData;
+struct FUserSaveData;
 
 UCLASS()
 class STILLLOADING_API USLUserDataSubsystem : public UGameInstanceSubsystem
@@ -29,7 +29,7 @@ public:
 	UFUNCTION(BlueprintCallable)
 	float GetCurrentScreenHeightSize();
 
-	void ApplyLoadedUserData(const FWidgetSaveData& LoadData);
+	void ApplyLoadedUserData(const FUserSaveData& LoadData);
 	void ApplyDefaultUserData();
 
 	void SetLanguage(ESLLanguageType NewType);


### PR DESCRIPTION
- `USLObjectiveSubsystem` 메서드 개선 (`GetObjectiveState`, `GetInProgressedObjectives` 등)
- 캐시 데이터 관리 방식 통합 (`CachedChapterObjectiveDataMap` -> `CachedObjectiveData`)
- 세이브/로드 관련 메서드 리네이밍 및 구조 개편 (`SaveGame` -> `SaveGameData`, `LoadGame` -> `LoadGameData` 등)
- 오브젝티브 기본 로드/저장 로직 추가 (`LoadObjectiveDefaultData`, `SaveObjectiveData`, `SendObjectiveData`)
- 사용자 데이터 구조 개편 (`FWidgetSaveData` -> `FUserSaveData`)
- 관련 데이터 및 맵 파일 업데이트 (`BP_SLIntroGameMode`, `L_Intro`)