### PR TITLE
[Update] 패리 및 강화된 공격 로직을 리팩토링하고 ToggleMenu를 제거합니다.

### DIFF
--- a/Content/StillLoading/Asset/VFX/SlashHitVFX/__GenericSource/FBX/SM_CurvedSword.uasset
+++ b/Content/StillLoading/Asset/VFX/SlashHitVFX/__GenericSource/FBX/SM_CurvedSword.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c3b6f4275dc345262b083edcd79e3baabd3d1921c607156e0d4b8daf24cc70a
-size 45753
+oid sha256:a3072cf4964489b19dd715e5821fbd1b38e09ecb853f9647ec5c6c59b189133b
+size 44150

--- a/Content/StillLoading/Asset/VFX/SlashHitVFX/__GenericSource/FBX/SM_Scythe.uasset
+++ b/Content/StillLoading/Asset/VFX/SlashHitVFX/__GenericSource/FBX/SM_Scythe.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f790a028127b3423bacf965fcb5267a66a0a34c20a4ad8f3da62bd449611586f
-size 94474
+oid sha256:cdf06e6df5999a2063849ffbc1ab562d0c56a196ae21da7c83062af7901ac76c
+size 93917

--- a/Content/StillLoading/Character/BP_SL2_5DPlayerCharacter.uasset
+++ b/Content/StillLoading/Character/BP_SL2_5DPlayerCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe4f71bbb64535c8074e69c8cce5ac7562620d0da37c42698a10f526fc6bc44f
-size 63414
+oid sha256:92b1fe429c04b4ae01e42976c25446e54affaaae2507a534997ff1fd528f931b
+size 64748

--- a/Source/StillLoading/AI/RealAI/Boid/BoidMovementComponent/BoidMovementComponent.cpp
+++ b/Source/StillLoading/AI/RealAI/Boid/BoidMovementComponent/BoidMovementComponent.cpp
@@ -226,7 +226,7 @@ void UBoidMovementComponent::HandleMovementState(float DeltaTime, ASwarmAgent* A
 	{
 		if (SeparationSq > 600) // 뒤에있어서 멀어지려는 힘이 약하고
 		{
-			OwnerCharacter->GetCharacterMovement()->StopMovementImmediately(); // 멈춰 or Anim
+			//OwnerCharacter->GetCharacterMovement()->StopMovementImmediately(); // 멈춰 or Anim
 			AMonsterAICharacter* Monster = Cast<AMonsterAICharacter>(Agent);
 			if (!Monster) return;
 			if (AbleToPlayWonderMontage)

--- a/Source/StillLoading/AI/RealAI/Boid/Service/BTService_FindPlayer.cpp
+++ b/Source/StillLoading/AI/RealAI/Boid/Service/BTService_FindPlayer.cpp
@@ -74,7 +74,7 @@ void UBTService_FindPlayer::TickNode(UBehaviorTreeComponent& OwnerComp, uint8* N
 			{
 				BlackboardComp->ClearValue(TargetActorKey.SelectedKeyName);
 				SwarmManager->SetSquadState(ESquadState::Patrolling_Move);
-				UE_LOG(LogTemp, Warning, TEXT("Target LOST. Clearing TargetActor."));
+				//UE_LOG(LogTemp, Warning, TEXT("Target LOST. Clearing TargetActor."));
 			}
 		}
 	}

--- a/Source/StillLoading/AI/RealAI/MonsterAICharacter.cpp
+++ b/Source/StillLoading/AI/RealAI/MonsterAICharacter.cpp
@@ -400,7 +400,7 @@ void AMonsterAICharacter::OnHitReceived(AActor* Causer, float Damage, const FHit
 	
 	HitDirection(Causer);
 	RotateToHitCauser(Causer);
-	ChangeMeshTemporarily();
+	//ChangeMeshTemporarily();
 	StartFlyingState();
 
 	LastAttacker = Causer;

--- a/Source/StillLoading/Character/MovementHandlerComponent/SL25DMovementHandlerComponent.cpp
+++ b/Source/StillLoading/Character/MovementHandlerComponent/SL25DMovementHandlerComponent.cpp
@@ -129,29 +129,38 @@ void USL25DMovementHandlerComponent::OnActionStarted_Implementation(EInputAction
 	case EInputActionType::EIAT_Attack:
 		// 패링 진입
 		{
-			const float CurrentTime = GetWorld()->GetTimeSeconds();
-			if (CurrentTime - LastBlockTime <= ParryDuration)
+			if (CachedCombatComponent->IsEmpowered())
 			{
-				UE_LOG(LogTemp, Warning, TEXT("Parring!!!"));
-
-				if (!CachedCombatComponent->IsEmpowered())
-				{
-					OwnerCharacter->ClearAllStateTags();
-
-					if (RightDot > 0.0f)
-						CachedMontageComponent->PlayBlockMontage(FName("ParryR"));
-					else
-						CachedMontageComponent->PlayBlockMontage(FName("ParryL"));
-
-					OwnerCharacter->AddSecondaryState(TAG_Character_Defense_Parry);
-					BlockCount = 0;
-				}
-
-				CachedCombatComponent->SetEmpoweredCombatMode(10);
-				USlowMotionHelper::ApplyGlobalSlowMotion(OwnerCharacter, 0.2f, 0.3f);
-
-				return;
+				CachedMontageComponent->PlaySkillMontage("SwordFromSky");
+				OwnerCharacter->SetPrimaryState(TAG_Character_Attack_SpawnSword);
 			}
+			else
+			{
+				const float CurrentTime = GetWorld()->GetTimeSeconds();
+				if (CurrentTime - LastBlockTime <= ParryDuration)
+				{
+					UE_LOG(LogTemp, Warning, TEXT("Parring!!!"));
+
+					if (!CachedCombatComponent->IsEmpowered())
+					{
+						OwnerCharacter->ClearAllStateTags();
+
+						if (RightDot > 0.0f)
+							CachedMontageComponent->PlayBlockMontage(FName("ParryR"));
+						else
+							CachedMontageComponent->PlayBlockMontage(FName("ParryL"));
+
+						OwnerCharacter->AddSecondaryState(TAG_Character_Defense_Parry);
+						BlockCount = 0;
+					}
+
+					BeginBuff();
+					USlowMotionHelper::ApplyGlobalSlowMotion(OwnerCharacter, 0.2f, 0.3f);
+
+					return;
+				}
+			}
+			
 			Attack();
 			break;
 		}
@@ -176,7 +185,6 @@ void USL25DMovementHandlerComponent::OnActionStarted_Implementation(EInputAction
 		DodgeLoco();
 		break;
 	case EInputActionType::EIAT_Menu:
-		ToggleMenu();
 	case EInputActionType::EIAT_LockObject:
 		break;
 
@@ -440,14 +448,6 @@ void USL25DMovementHandlerComponent::DodgeLoco()
 	FaceMouseCursorInstantly();
 	CachedMontageComponent->PlayDodgeMontage("Forward");
 	OwnerCharacter->SetPrimaryState(TAG_Character_Movement_Dodge);
-}
-
-void USL25DMovementHandlerComponent::ToggleMenu()
-{
-	UE_LOG(LogTemp, Log, TEXT("Menu opened or closed"));
-	// TODO: UI 호출 / Input 모드 변경 등 처리
-
-	// HUD에 OnPose
 }
 
 void USL25DMovementHandlerComponent::Block(const bool bIsBlocking)

--- a/Source/StillLoading/Character/MovementHandlerComponent/SL25DMovementHandlerComponent.h
+++ b/Source/StillLoading/Character/MovementHandlerComponent/SL25DMovementHandlerComponent.h
@@ -74,8 +74,6 @@ protected:
 	UFUNCTION()
 	void DodgeLoco();
 	UFUNCTION()
-	void ToggleMenu();
-	UFUNCTION()
 	void Block(bool bIsBlocking);
 	UFUNCTION()
 	void Attack();

--- a/Source/StillLoading/Character/MovementHandlerComponent/SLMovementHandlerComponent.cpp
+++ b/Source/StillLoading/Character/MovementHandlerComponent/SLMovementHandlerComponent.cpp
@@ -1426,10 +1426,6 @@ void UMovementHandlerComponent::OnAttackStageFinished(ECharacterMontageState Att
 		OwnerCharacter->ChangeVisibilityWeapons(true);
 		break;
 	case ECharacterMontageState::ECS_Attack_SpawnSword:
-		if (USLSkillComponent* SkillComp = OwnerCharacter->FindComponentByClass<USLSkillComponent>())
-		{
-			SkillComp->ActivateSkill(EActiveSkillType::AST_Spawn);
-		}
 		CachedMontageComponent->PlaySkillMontage("Dodge");
 		break;
 	case ECharacterMontageState::ECS_Attack_SpawnSwordDodge:


### PR DESCRIPTION
SL25DMovementHandlerComponent에서 패리 및 강화된 공격 처리를 재작업하여 강화된 공격의 우선순위를 정하고 패리 로직을 간소화했습니다. 사용되지 않는 ToggleMenu 함수와 해당 참조를 제거했습니다. 더욱 깔끔한 출력을 위해 AI 및 캐릭터 클래스의 디버그 로그와 임시 메시 변경 사항을 주석 처리했습니다. 검과 낫 모델의 애셋 파일을 업데이트했습니다.